### PR TITLE
GitZen accounts are now configurable and the home page now has baseline functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a web application built using Django that links Zendesk and Github for easier developer management.
 
-### Deploying the application to Heroku (on Ubuntu)
+### Setting up the environment for Heroku deployment (on Ubuntu)
 
 1. Make a Heroku account on their [website](http://www.heroku.com/).
 
@@ -11,8 +11,8 @@ This is a web application built using Django that links Zendesk and Github for e
 
 3. Login to Heroku by running the command
 	>`heroku login`
-	
-	and filling out the requested credentials.
+
+and filling out the requested credentials.
 
 4. Install python and virtualenv. (A guide for this can be found [here](http://docs.python-guide.org/en/latest/starting/install/linux/))
 
@@ -37,13 +37,16 @@ This is a web application built using Django that links Zendesk and Github for e
 10. Install the required packages for GitZen and Heroku with pip by using the command
 	>`pip install -r requirements.txt`
 
-11. Create the app on the Heroku Cedar stack by running the command
+
+### Deploying the application to Heroku (on Ubuntu)
+
+1. Create the app on the Heroku Cedar stack by running the command
 	>`heroku create --stack cedar`
 
-12. Deploy the app with the command
+2. Deploy the app with the command
 	>`git push heroku master`
 
-13. The command
+3. The command
 	>`heroku logs`
 
 	can be used to view the logs of the app if desired, and the command
@@ -51,7 +54,7 @@ This is a web application built using Django that links Zendesk and Github for e
 
 	can be used to visit the app on the web.
 
-14. In order to conduct one-off admin processes for the app in django, preface the commands with
+4. In order to conduct one-off admin processes for the app in django, preface the commands with
 	>`heroku run`
 
 	An example of this would be syncing the databases in django by using the command
@@ -63,7 +66,7 @@ This is a web application built using Django that links Zendesk and Github for e
 
 2. Located under the heading "New User", begin filling out the information to create a new user by first assigning them a username and password and filling the "Username", "Password", and "Affirm Password" fields with this information.
 
-3. In order to use GitHub ticket information in GitZen, each user must provide a set of access information from a GitHub account linked to the repository from which the ticket information should be monitored. This access information consists of a GitHub username, repository name, and API key associated with the desired ticket information, and those access parameters should be filled into the "GitHub Username", "GitHub Repository", and "GitHub API Key" fields in the new user form respectively.
+3. In order to use GitHub ticket information in GitZen, each user must provide a set of access information from a GitHub account linked to the repository from which the ticket information should be monitored. This access information consists of a GitHub username, password, organization name, and repository name associated with the desired ticket information, and those access parameters should be filled into the "GitHub Username", "GitHub Password", "GitHub Organization", and "GitHub Repository" fields in the new user form respectively. If the repository is under a user account rather than an organization, provide the username in the organization field instead.
 
 4. In order to use Zendesk ticket information in GitZen, each user must provide a set of access information from a Zendesk account linked to the tickets that should be monitored. The first information required to access this data is a Zendesk user email and password, and those access parameters should be filled into the "Zendesk User Email" and "Zendesk Password" fields in the new user form respectively. The other three bits of Zendesk access information needed are more specific and are covered in the following steps.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a web application built using Django that links Zendesk and Github for e
 3. Login to Heroku by running the command
 	>`heroku login`
 
-and filling out the requested credentials.
+	and filling out the requested credentials.
 
 4. Install python and virtualenv. (A guide for this can be found [here](http://docs.python-guide.org/en/latest/starting/install/linux/))
 
@@ -35,8 +35,7 @@ and filling out the requested credentials.
 	to install the necessary packages that allow for the installation of psycopg2 (Postgresql support for python) in the following step.
 
 10. Install the required packages for GitZen and Heroku with pip by using the command
-	>`pip install -r requirements.txt`
-
+	>`pip install -r requirements.txt` 
 
 ### Deploying the application to Heroku (on Ubuntu)
 
@@ -66,15 +65,18 @@ and filling out the requested credentials.
 
 2. Located under the heading "New User", begin filling out the information to create a new user by first assigning them a username and password and filling the "Username", "Password", and "Affirm Password" fields with this information.
 
-3. In order to use GitHub ticket information in GitZen, each user must provide a set of access information from a GitHub account linked to the repository from which the ticket information should be monitored. This access information consists of a GitHub username, password, organization name, and repository name associated with the desired ticket information, and those access parameters should be filled into the "GitHub Username", "GitHub Password", "GitHub Organization", and "GitHub Repository" fields in the new user form respectively. If the repository is under a user account rather than an organization, provide the username in the organization field instead.
+3. In order to use GitHub ticket information in GitZen, each user must provide a set of access information from a GitHub account linked to the repository from which the ticket information should be monitored. This access information consists of a GitHub username, password, organization name, and repository name associated with the desired ticket information, and those access parameters should be filled into the "GitHub Username", "GitHub Password", "GitHub Organization", and "GitHub Repository" fields in the new user form respectively. If the repository is under a user account rather than an organization, provide the username of that account in the organization field instead.
 
-4. In order to use Zendesk ticket information in GitZen, each user must provide a set of access information from a Zendesk account linked to the tickets that should be monitored. The first information required to access this data is a Zendesk user email and password, and those access parameters should be filled into the "Zendesk User Email" and "Zendesk Password" fields in the new user form respectively. The other three bits of Zendesk access information needed are more specific and are covered in the following steps.
+4. In order to use Zendesk ticket information in GitZen, each user must provide a set of access information from a Zendesk account linked to the tickets that should be monitored. The first information required to access this data is a Zendesk user email which should be filled into the "Zendesk User Email" field in the new user form. The other three bits of Zendesk access information needed are more specific and are covered in the following steps.
 
-5. For the "Zendesk URL" field in the new user form, enter in the full URL that comes up after logging into a Zendesk account associated with the desired ticket information.
+5. In order to allow API token access to the Zendesk account, "Token Access" must be enabled. This option can be found by logging into Zendesk with an account that has administrator level credentials and looking under "Settings"->"Channels"->"API". After clicking "edit" and checking the "Token Access" box, copy the the displayed API token and paste it into the "Zendesk API Token" field in the new user form.
 
-6. For the "Zendesk Ticket View ID" field in the new user form, enter in the ID number assigned by Zendesk to the desired group of tickets.
+6. For the "Zendesk URL" field in the new user form, enter in the full URL that comes up after logging into the Zendesk account associated with the desired ticket information (The URL should be in the format "https://\{yourcompanyname\}.zendesk.com").
 
-7. For the "Zendesk Ticket Association Field" field in the new user form, enter in the full name of the field that holds the external ticket association data for each Zendesk ticket. If a defualt named was used for this field, the name will probably be in the format "field-######" where the "#" are numbers between 0-9.
+7. For the "Zendesk Ticket Association Field ID" field in the new user form, the ID number of the field that holds the external ticket association data for each Zendesk ticket must be found. In order to find this ID number, first look up the ID number of a Zendesk ticket from the desired account that has this ticket association field on it. Then open up a command terminal and enter in the following command, substituting the parameters surrounded by braces with the information from the desired Zendesk account and substituting the `id` parameter with the ticket ID number that was just looked up:
+	>`curl {zendesk_url}/api/v2/tickets/{id}.json -u {email_address}/token:{api_token}`
+
+	From the output of this command, look for the dictionary key "fields", and within the dictionaries listed for the value of this key, look for the one with the value of the "value" key matching the value of the ticket association field of the Zendesk ticket that was looked up for this process. In the same dictionary as this "value" pair, the number value for the "id" key is the ID number that must be entered into the "Zendesk Ticket Association Field ID" field in the new user form.
 
 8. Check to see that all fields under the "New User" heading are filled out accuracely, and then click the "Create User" button to create a user with the given information. A confirmation page should come up after this process that will have a link to return to the login screen.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GitZen
 
-This is a web application built using Django that links Zendesk and Github for easier developer management.
+This is a web application built using Django that links Zendesk and Github for
+easier developer management.
 
 ### Setting up the environment for Heroku deployment (on Ubuntu)
 
@@ -14,27 +15,33 @@ This is a web application built using Django that links Zendesk and Github for e
 
 	and filling out the requested credentials.
 
-4. Install python and virtualenv. (A guide for this can be found [here](http://docs.python-guide.org/en/latest/starting/install/linux/))
+4. Install python and virtualenv. (A guide for this can be found
+[here](http://docs.python-guide.org/en/latest/starting/install/linux/))
 
-5. Install a version of Postgres from [here](http://www.postgresql.org/download/) so testing can be done locally.
+5. Install a version of Postgres from
+[here](http://www.postgresql.org/download/) so testing can be done locally.
 
 6. Clone the GitZen repo with the command
 	>`git clone git://github.com/FriedRice/GitZen.git`
 
-7. Change directories to the newly cloned GitZen directory and setup a virualenv using the command
+7. Change directories to the newly cloned GitZen directory and setup a virualenv
+using the command
 	>`virtualenv venv --distribute`
 
 8. Activate the virtualenv with the command
 	>`source venv/bin/activate`  
 		
-	You must source the virtualenv environment for each terminal session where you wish to run your app.
+	You must source the virtualenv environment for each terminal session where
+you wish to run your app.
 
 9. Run the command
 	>`sudo apt-get install libpq-dev python-dev`
 
-	to install the necessary packages that allow for the installation of psycopg2 (Postgresql support for python) in the following step.
+	to install the necessary packages that allow for the installation of
+psycopg2 (Postgresql support for python) in the following step.
 
-10. Install the required packages for GitZen and Heroku with pip by using the command
+10. Install the required packages for GitZen and Heroku with pip by using the
+command
 	>`pip install -r requirements.txt` 
 
 ### Deploying the application to Heroku (on Ubuntu)
@@ -53,30 +60,72 @@ This is a web application built using Django that links Zendesk and Github for e
 
 	can be used to visit the app on the web.
 
-4. In order to conduct one-off admin processes for the app in django, preface the commands with
+4. In order to conduct one-off admin processes for the app in django, preface
+the commands with
 	>`heroku run`
 
-	An example of this would be syncing the databases in django by using the command
+	An example of this would be syncing the databases in django by using the
+command
 	>`heroku run python manage.py syncdb`
 
 ### Configuration Instructions
 
 1. Go to the [GitZen website](http://gitzen.herokuapp.com) on Heroku.
 
-2. Located under the heading "New User", begin filling out the information to create a new user by first assigning them a username and password and filling the "Username", "Password", and "Affirm Password" fields with this information.
+2. Located under the heading "New User", begin filling out the information to
+create a new user by first assigning them a username and password and filling
+the "Username", "Password", and "Affirm Password" fields with this information.
 
-3. In order to use GitHub ticket information in GitZen, each user must provide a set of access information from a GitHub account linked to the repository from which the ticket information should be monitored. This access information consists of a GitHub username, password, organization name, and repository name associated with the desired ticket information, and those access parameters should be filled into the "GitHub Username", "GitHub Password", "GitHub Organization", and "GitHub Repository" fields in the new user form respectively. If the repository is under a user account rather than an organization, provide the username of that account in the organization field instead.
+3. In order to use GitHub ticket information in GitZen, each user must provide a
+set of access information from a GitHub account linked to the repository from
+which the ticket information should be monitored. This access information
+consists of a GitHub username, password, organization name, and repository name
+associated with the desired ticket information, and those access parameters
+should be filled into the "GitHub Username", "GitHub Password", "GitHub
+Organization", and "GitHub Repository" fields in the new user form respectively.
+If the repository is under a user account rather than an organization, provide
+the username of that account in the organization field instead.
 
-4. In order to use Zendesk ticket information in GitZen, each user must provide a set of access information from a Zendesk account linked to the tickets that should be monitored. The first information required to access this data is a Zendesk user email which should be filled into the "Zendesk User Email" field in the new user form. The other three bits of Zendesk access information needed are more specific and are covered in the following steps.
+4. In order to use Zendesk ticket information in GitZen, each user must provide
+a set of access information from a Zendesk account linked to the tickets that
+should be monitored. The first information required to access this data is a
+Zendesk user email which should be filled into the "Zendesk User Email" field in
+the new user form. The other three bits of Zendesk access information needed are
+more specific and are covered in the following steps.
 
-5. In order to allow API token access to the Zendesk account, "Token Access" must be enabled. This option can be found by logging into Zendesk with an account that has administrator level credentials and looking under "Settings"->"Channels"->"API". After clicking "edit" and checking the "Token Access" box, copy the the displayed API token and paste it into the "Zendesk API Token" field in the new user form.
+5. In order to allow API token access to the Zendesk account, "Token Access"
+must be enabled. This option can be found by logging into Zendesk with an
+account that has administrator level credentials and looking under
+"Settings"->"Channels"->"API". After clicking "edit" and checking the "Token
+Access" box, copy the displayed API token and paste it into the "Zendesk API
+Token" field in the new user form.
 
-6. For the "Zendesk URL" field in the new user form, enter in the full URL that comes up after logging into the Zendesk account associated with the desired ticket information (The URL should be in the format "https://\{yourcompanyname\}.zendesk.com").
+6. For the "Zendesk URL" field in the new user form, enter in the full URL that
+comes up after logging into the Zendesk account associated with the desired
+ticket information (The URL should be in the format
+"https://\{yourcompanyname\}.zendesk.com").
 
-7. For the "Zendesk Ticket Association Field ID" field in the new user form, the ID number of the field that holds the external ticket association data for each Zendesk ticket must be found. In order to find this ID number, first look up the ID number of a Zendesk ticket from the desired account that has this ticket association field on it. Then open up a command terminal and enter in the following command, substituting the parameters surrounded by braces with the information from the desired Zendesk account and substituting the `id` parameter with the ticket ID number that was just looked up:
-	>`curl {zendesk_url}/api/v2/tickets/{id}.json -u {email_address}/token:{api_token}`
+7. For the "Zendesk Ticket Association Field ID" field in the new user form, the
+ID number of the field that holds the external ticket association data for each
+Zendesk ticket must be found. In order to find this ID number, first look up the
+ID number of a Zendesk ticket from the desired account that has this ticket
+association field on it. Then open up a command terminal and enter in the
+following command, substituting the parameters surrounded by braces with the
+information from the desired Zendesk account and substituting the `id` parameter
+with the ticket ID number that was just looked up:
+	>`curl {zendesk_url}/api/v2/tickets/{id}.json -u
+	>{email_address}/token:{api_token}`
 
-	From the output of this command, look for the dictionary key "fields", and within the dictionaries listed for the value of this key, look for the one with the value of the "value" key matching the value of the ticket association field of the Zendesk ticket that was looked up for this process. In the same dictionary as this "value" pair, the number value for the "id" key is the ID number that must be entered into the "Zendesk Ticket Association Field ID" field in the new user form.
+	From the output of this command, look for the dictionary key "fields", and
+within the dictionaries listed for the value of this key, look for the one with
+the value of the "value" key matching the value of the ticket association field
+of the Zendesk ticket that was looked up for this process. In the same
+dictionary as this "value" pair, the number value for the "id" key is the ID
+number that must be entered into the "Zendesk Ticket Association Field ID" field
+in the new user form.
 
-8. Check to see that all fields under the "New User" heading are filled out accuracely, and then click the "Create User" button to create a user with the given information. A confirmation page should come up after this process that will have a link to return to the login screen.
+8. Check to see that all fields under the "New User" heading are filled out
+accurately, and then click the "Create User" button to create a user with the
+given information. A confirmation page should come up after this process that
+will have a link to return to the login screen.
 

--- a/associations/models.py
+++ b/associations/models.py
@@ -4,12 +4,11 @@ from encryption import EncryptedCharField
 
 class GZUser(User):
     git_name = models.CharField(max_length=75)
-    git_pass = EncryptedCharField(max_length=75)
-    git_org = models.CharField(max_length=75)
     git_repo = models.CharField(max_length=75)
+    git_key = EncryptedCharField(max_length=75)
     zen_name = models.CharField(max_length=75)
-    zen_token = EncryptedCharField(max_length=75)
     zen_url = models.CharField(max_length=100)
-    zen_fieldid = models.CharField(max_length=50)
+    zen_viewid = models.CharField(max_length=25)
+    zen_pass = EncryptedCharField(max_length=75)
 
     objects = UserManager()

--- a/associations/models.py
+++ b/associations/models.py
@@ -4,11 +4,12 @@ from encryption import EncryptedCharField
 
 class GZUser(User):
     git_name = models.CharField(max_length=75)
+    git_pass = EncryptedCharField(max_length=75)
+    git_org = models.CharField(max_length=75)
     git_repo = models.CharField(max_length=75)
-    git_key = EncryptedCharField(max_length=75)
     zen_name = models.CharField(max_length=75)
+    zen_token = EncryptedCharField(max_length=75)
     zen_url = models.CharField(max_length=100)
-    zen_viewid = models.CharField(max_length=25)
-    zen_pass = EncryptedCharField(max_length=75)
+    zen_fieldid = models.CharField(max_length=50)
 
     objects = UserManager()

--- a/associations/models.py
+++ b/associations/models.py
@@ -5,10 +5,10 @@ from encryption import EncryptedCharField
 class GZUser(User):
     git_name = models.CharField(max_length=75)
     git_repo = models.CharField(max_length=75)
-    git_key = EncryptedCharField(max_length=75, initial='')
+    git_key = EncryptedCharField(max_length=75, default='')
     zen_name = models.CharField(max_length=75)
     zen_url = models.CharField(max_length=100)
-    zen_viewid = models.CharField(max_length=25, intial='')
-    zen_pass = EncryptedCharField(max_length=75, intial='')
+    zen_viewid = models.CharField(max_length=25, default='')
+    zen_pass = EncryptedCharField(max_length=75, default='')
 
     objects = UserManager()

--- a/associations/models.py
+++ b/associations/models.py
@@ -4,8 +4,9 @@ from encryption import EncryptedCharField
 
 class GZUser(User):
     git_name = models.CharField(max_length=75)
+    git_pass = EncryptedCharField(max_length=75)
+    git_org = models.CharField(max_length=75)
     git_repo = models.CharField(max_length=75)
-    git_key = EncryptedCharField(max_length=75)
     zen_name = models.CharField(max_length=75)
     zen_pass = EncryptedCharField(max_length=75)
     zen_url = models.CharField(max_length=100)

--- a/associations/models.py
+++ b/associations/models.py
@@ -8,9 +8,8 @@ class GZUser(User):
     git_org = models.CharField(max_length=75)
     git_repo = models.CharField(max_length=75)
     zen_name = models.CharField(max_length=75)
-    zen_pass = EncryptedCharField(max_length=75)
+    zen_token = EncryptedCharField(max_length=75)
     zen_url = models.CharField(max_length=100)
-    zen_viewid = models.CharField(max_length=25)
     zen_fieldid = models.CharField(max_length=50)
 
     objects = UserManager()

--- a/associations/models.py
+++ b/associations/models.py
@@ -5,10 +5,10 @@ from encryption import EncryptedCharField
 class GZUser(User):
     git_name = models.CharField(max_length=75)
     git_repo = models.CharField(max_length=75)
-    git_key = EncryptedCharField(max_length=75)
+    git_key = EncryptedCharField(max_length=75, initial='')
     zen_name = models.CharField(max_length=75)
     zen_url = models.CharField(max_length=100)
-    zen_viewid = models.CharField(max_length=25)
-    zen_pass = EncryptedCharField(max_length=75)
+    zen_viewid = models.CharField(max_length=25, intial='')
+    zen_pass = EncryptedCharField(max_length=75, intial='')
 
     objects = UserManager()

--- a/associations/templates/associations/change.html
+++ b/associations/templates/associations/change.html
@@ -38,14 +38,19 @@ User password.</p>
         {{ changeform.git_name }}
     </div>
     <div class="fieldWrapper">
+        {{ changeform.git_pass.errors }}
+        <label for="id_git_pass">GitHub Password:</label>
+        {{ changeform.git_pass }}
+    </div>
+    <div class="fieldWrapper">
+        {{ changeform.git_org.errors }}
+        <label for="id_git_org">GitHub Organization:</label>
+        {{ changeform.git_org }}
+    </div>
+    <div class="fieldWrapper">
         {{ changeform.git_repo.errors }}
         <label for="id_git_repo">GitHub Repository:</label>
         {{ changeform.git_repo }}
-    </div>
-    <div class="fieldWrapper">
-        {{ changeform.git_key.errors }}
-        <label for="id_git_key">GitHub API Key:</label>
-        {{ changeform.git_key }}
     </div>
     <div class="fieldWrapper">
         {{ changeform.zen_name.errors }}
@@ -74,5 +79,6 @@ User password.</p>
 	</div>
     <p><input name="change" type="submit" value="Submit Changes" /></p>
 </form>
+
 </body>
 </html>

--- a/associations/templates/associations/change.html
+++ b/associations/templates/associations/change.html
@@ -58,23 +58,18 @@ User password.</p>
         {{ changeform.zen_name }}
     </div>
     <div class="fieldWrapper">
-        {{ changeform.zen_pass.errors }}
-        <label for="id_zen_pass">Zendesk Password:</label>
-        {{ changeform.zen_pass }}
+        {{ changeform.zen_token.errors }}
+        <label for="id_zen_token">Zendesk API Token:</label>
+        {{ changeform.zen_token }}
     </div> 
     <div class="fieldWrapper">
         {{ changeform.zen_url.errors }}
         <label for="id_zen_url">Zendesk URL:</label>
         {{ changeform.zen_url }}
     </div>
-    <div class="fieldWrapper">
-        {{ changeform.zen_viewid.errors }}
-        <label for="id_zen_url">Zendesk Ticket View ID:</label>
-        {{ changeform.zen_viewid }}
-	</div>
 	<div class="fieldWrapper">
 		{{ changeform.zen_fieldid.errors }}
-		<label for="id_zen_fieldid">Zendesk Ticket Association Field:</label>
+		<label for="id_zen_fieldid">Zendesk Ticket Association Field ID:</label>
 		{{ changeform.zen_fieldid }}
 	</div>
     <p><input name="change" type="submit" value="Submit Changes" /></p>

--- a/associations/templates/associations/home.html
+++ b/associations/templates/associations/home.html
@@ -33,7 +33,7 @@
 	a.open, td.open {
 		color:green
 	}
-	a.close, td.close {
+	a.closed, td.closed {
 		color:red
 	}
 
@@ -49,7 +49,7 @@
 <h3><a href="/change/">Change Account Data</a></h3>
 
 <h2>Associations</h2>
-{% if working.o_assocs %}
+{% if status.o_assocs %}
     <h3>Open Associations</h3>
     {% if o_assocs %}
         <table align="center" style="width:75%">
@@ -118,7 +118,7 @@
 				{% else %}
 					<td class="open">{{ a.z_date }}</td>
 				{% endif %}
-				<td>{{ a.guser }}</td>
+				<td>{{ a.g_user }}</td>
 				{% if a.closed == 'g' %}
 					<td class="closed">{{ a.g_date }}</td>
 				{% else %}
@@ -144,29 +144,33 @@
     <h3>Not Associated with GitHub</h3>
     {% if no_assocs %}
         <table align="center" style="width:50%">
-        <tr>
-        <th>Zendesk Ticket</th>
-        <th>Zendesk User</th>
-        <th>Last Updated</th>
-        <th>Displayed Association</th>
-        </tr>
+			<tr>
+				<th>Zendesk Ticket</th>
+				<th>Zendesk User</th>
+				<th>Last Updated</th>
+				<th>Displayed Association</th>
+			</tr>
         {% for a in no_assocs %}
             <tr>
-            <td align="center"><a href="{{ zen_url }}/tickets/{{ a.znum }}?col={{ zen_viewid }}">Z{{ a.znum }}</a></td>
-            <td align="center">{{ a.zuser }}</td>
-            <td align="center">{{ a.zdate }}</td>
-            <td align="center">{{ a.dassoc }}</td>
+            	<td><a class="open" href="{{ zen_url }}/tickets/
+						{{ a.z_id }}">Z{{ a.z_id }}</a>
+				</td>
+				<td>{{ a.z_user }}</td>
+				<td class="open">{{ a.z_date }}</td>
+				<td>{{ a.assoc }}</td>
             </tr>
         {% endfor %}
         </table>
     {% else %}
-        <p align="center">There are currently no Zendesk Tickets without Git
-        Associations.</p>
+        <p align="center">There are currently no Zendesk Tickets without GitHub 
+							Associations.</p>
     {% endif %}
 {% else %}
     <p align="center">There was an Error connecting to either GitHub or
     Zendesk. Try adjusting your account settings.</p>
 {% endif %}
+
+<!--
 
 <br/><br/>
 
@@ -186,7 +190,7 @@
 		<th>Subject</th>
 	</tr>
 
-    {% if working.git %}
+    {% if status.git %}
         {% if git_tics %}
             {% for i in git_tics %}
 			<tr>
@@ -274,6 +278,6 @@
 		to Zendesk. Try adjusting your account settings.</td></tr>
     {% endif %}
 </table>
-
+-->
 </body>
 </html>

--- a/associations/templates/associations/home.html
+++ b/associations/templates/associations/home.html
@@ -100,29 +100,44 @@
 				<th>Git Issue Labels</th>
 			</tr>
         {% for a in ho_assocs %}
-            <tr>
-            	<td><a href="{{ zen_url }}/tickets/{{ a.znum }}?col={{ zen_viewid }}">Z{{ a.znum }}</a> --&gt; 
-            <a href="https://github.com/{{ repo }}/issues/{{ a.gnum }}">G{{ a.gnum }}</a></td>
-            <td align="center">{{ a.zuser }}</td>
-            <td align="center">{{ a.zdate }}</td>
-            <td align="center">{{ a.guser }}</td>
-            <td align="center">
-            {% if a.glabels %}
-                {% for b in a.glabels %}
-                    {{ b }},
-                {% endfor %}
-            {% else %}
-                None
-            {% endif %}
-            </td>
-            <td align="center"> 
-                <span style="color:green">Open ({{ a.gdate }})</span>
-            </td>
+			<tr>
+				<td>
+				{% if a.closed == 'g' %}
+					<a class="open" href="{{ zen_url }}/tickets/
+						{{ a.z_id }}">Z{{ a.z_id }}</a> --&gt; 
+					<a class="closed" href="a.g_url">G{{ a.g_id }}</a>
+				{% else %}
+					<a class="closed" href="{{ zen_url }}/tickets/
+						{{ a.z_id }}">Z{{ a.z_id }}</a> --&gt; 
+					<a class="open" href="a.g_url">G{{ a.g_id }}</a>
+				{% endif %}
+				</td>
+				<td>{{ a.z_user }}</td>
+				{% if a.closed == 'z' %}
+					<td class="closed">{{ a.z_date }}</td>
+				{% else %}
+					<td class="open">{{ a.z_date }}</td>
+				{% endif %}
+				<td>{{ a.guser }}</td>
+				{% if a.closed == 'g' %}
+					<td class="closed">{{ a.g_date }}</td>
+				{% else %}
+					<td class="open">{{ a.g_date }}</td>
+				{% endif %}
+				<td>
+				{% if a.g_labels %}
+					{% for l in a.g_labels %}
+						{{ l }},
+					{% endfor %}
+				{% else %}
+					None
+				{% endif %}
+				</td>
             </tr>
         {% endfor %}
         </table>
     {% else %}
-        <p align="center">There are currently no open Associations.</p>
+        <p align="center">There are currently no half-open Associations.</p>
     {% endif %}
     <br/>
 

--- a/associations/templates/associations/home.html
+++ b/associations/templates/associations/home.html
@@ -155,8 +155,7 @@
             adjusting your account settings.</td></tr>
         {% endif %}
     {% else %}
-        <tr><td align="center">There are currently no open GitHub 
-        Tickets.</td></tr>
+        <tr><td align="center">There are currently no open GitHub Tickets.</td></tr>
     {% endif %}
     </table>
 </td>

--- a/associations/templates/associations/home.html
+++ b/associations/templates/associations/home.html
@@ -2,18 +2,34 @@
 <head>
 <style type="text/css">
     table, td, th {
-        border:1px solid black;
+		border:1px solid black;
     }
     table.noborder, td.noborder, th.noborder {
         border:0px;
-    }
+	}
+	table.ref_tics {
+		width:35%;
+	}
+	table.ref_users {
+		width:60%;
+		margin-left:20%;
+		margin-right:20%;
+	}
     td {
-        padding:5px;
-    }
+		padding:5px;
+		text-align:center;
+	}
+	table#table_tics {
+		width:84%;
+		margin-left:8%;
+		margin-right:8%;
+	}
+
     a:link, a:visited {
         text-decoration:none;
         color:blue;
-    }
+	}
+
     h1, h2, h3{
         text-align:center;
     }
@@ -27,7 +43,7 @@
 <br/>
 
 <h2>Associations</h2>
-{% if c_assocs != 'broken' %}
+{% if working.c_assocs %}
     <h3>Closed Associations</h3>
     {% if c_assocs %}
         <table align="center" style="width:75%">
@@ -132,30 +148,43 @@
 
 <br/><br/>
 
-<table class="noborder" style="width:100%;">
-<tr><td class="noborder" colspan="3">
-<h2>GitHub and Zendesk Info</h2>
-</td></tr>
+<h2>Quick Reference</h2>
+<br/>
 
+<table id="table_tics" class="noborder">
+<col width="90%" />
 <tr>
 <td class="noborder">
     <table>
     <tr>
-    <th>Open GitHub Tickets</th>
-    </tr>
+    	<th colspan="2">Open GitHub Tickets</th>
+	</tr>
+	<tr>
+		<th>Issue #</th>
+		<th>Subject</th>
+	</tr>
 
-    {% if gitTics %}
-        {% if gitTics != 'broken' %}
-            {% for i in gitTics %}
-                <tr><td>
-                <a href='https://github.com/{{ repo }}/issues/{{ i.number }}'>{{ i.number }}.</a>                 {{ i.title }}</td></tr>
+    {% if working.git %}
+        {% if git_tics %}
+            {% for i in git_tics %}
+			<tr>
+				<td>
+					<a href='https://github.com/{{ repo }}
+						/issues/{{ i.number }}'>{{ i.number }}</a>
+				</td>
+				<td>
+					{{ i.title }}
+				</td>
+			</tr>
             {% endfor %}
         {% else %}
-            <tr><td align="center">There was an Error connecting to GitHub. Try 
-            adjusting your account settings.</td></tr>
+		<tr><td align="center">There are currently no open 
+				GitHub Tickets.</td></tr>
+		<tr><td align="center">There was an Error connecting to GitHub. Try 
         {% endif %}
     {% else %}
-        <tr><td align="center">There are currently no open GitHub Tickets.</td></tr>
+		<tr><td align="center">There was an Error connecting to GitHub. Try 
+		adjusting your account settings.</td></tr>
     {% endif %}
     </table>
 </td>
@@ -170,9 +199,9 @@
     <th>Requester</th>
     </tr>
 
-    {% if zenTics %}
-        {% if zenTics != 'broken' %}
-            {% for t in zenTics %}
+    {% if working.zen %}
+        {% if zen_tics %}
+            {% for t in zen_tics %}
                 <tr>
                 <td><a href="{{ zen_url }}/tickets/{{ t.id }}?col={{ zen_viewid }}">{{ t.id }}.</a> 
                 {{ t.subject }}</td>
@@ -180,30 +209,33 @@
                 </tr>
             {% endfor %}
         {% else %}
-            <tr><td align="center" colspan="2">There was an Error connecting 
-            to Zendesk. Try adjusting your account settings.</td></tr>
+			<tr><td align="center" colspan="2">There are currently no Zendesk
+			Tickets.</td></tr>
         {% endif %}
     {% else %}
-        <tr><td align="center" colspan="2">There are currently no Zendesk
-        Tickets.</td></tr>
+		<tr><td align="center" colspan="2">There was an Error connecting 
+		to Zendesk. Try adjusting your account settings.</td></tr>
     {% endif %}
     </table>
 </td>
+</tr>
+</table>
 
-<td class="noborder">
-    <table>
+<br/>
+
+<table class="ref_users">
     <tr>
-    <th colspan="3">Zendesk Users</th>
+    	<th colspan="3">Zendesk Users</th>
     </tr>
     <tr>
-    <th>Name</th>
-    <th>Email</th>
-    <th>Organization</th>
+		<th>Name</th>
+		<th>Email</th>
+		<th>Organization</th>
     </tr>
 
-    {% if zenUsers %}
-        {% if zenUsers != 'broken' %}
-            {% for u in zenUsers %}
+    {% if working.zen %}
+        {% if zen_users %}
+            {% for u in zen_users %}
                 <tr>
                 <td align="center"><a href="{{ zen_url }}/users/{{ u.id }}"
                 >{{ u.name }}</a></td>
@@ -212,16 +244,13 @@
                 </tr>
             {% endfor %}
         {% else %}
-            <tr><td align="center" colspan="3">There was an Error connecting 
-            to Zendesk. Try adjusting your account settings.</td></tr>
+			<tr><td align="center" colspan="3">There are currently no Zendesk 
+			users.</td></tr>
         {% endif %}
     {% else %}
-        <tr><td align="center" colspan="3">There are currently no Zendesk 
-        users.</td></tr>
+		<tr><td align="center" colspan="3">There was an Error connecting 
+		to Zendesk. Try adjusting your account settings.</td></tr>
     {% endif %}
-    </table>
-</td>
-</tr>
 </table>
 
 </body>

--- a/associations/templates/associations/home.html
+++ b/associations/templates/associations/home.html
@@ -15,14 +15,14 @@
 		margin-left:20%;
 		margin-right:20%;
 	}
-    td {
-		padding:5px;
-		text-align:center;
-	}
 	table#table_tics {
 		width:84%;
 		margin-left:8%;
 		margin-right:8%;
+	}
+    td {
+		padding:5px;
+		text-align:center;
 	}
 
     a:link, a:visited {
@@ -30,7 +30,14 @@
         color:blue;
 	}
 
-    h1, h2, h3{
+	a.open, td.open {
+		color:green
+	}
+	a.close, td.close {
+		color:red
+	}
+
+    h1, h2, h3 {
         text-align:center;
     }
 </style>
@@ -40,61 +47,61 @@
 <body>
 <h1>GitZen</h1>
 <h3><a href="/change/">Change Account Data</a></h3>
-<br/>
 
 <h2>Associations</h2>
-{% if working.c_assocs %}
-    <h3>Closed Associations</h3>
-    {% if c_assocs %}
+{% if working.o_assocs %}
+    <h3>Open Associations</h3>
+    {% if o_assocs %}
         <table align="center" style="width:75%">
-        <tr>
-        <th>Association</th>
-        <th>Zendesk User</th>
-        <th>Last Zen Ticket Update</th>
-        <th>GitHub User</th>
-        <th>Git Issue Labels</th>
-        <th>Git Status</th>
-        </tr>
-        {% for a in c_assocs %}
+			<tr>
+				<th>Association</th>
+				<th>Zendesk User</th>
+				<th>Last Zen Ticket Update</th>
+				<th>GitHub User</th>
+				<th>Last Git Ticket Update</th>
+				<th>Git Issue Labels</th>
+			</tr>
+        {% for a in o_assocs %}
             <tr>
-            <td align="center"><a href="{{ zen_url }}/tickets/{{ a.znum }}?col={{ zen_viewid }}">Z{{ a.znum }}</a> --&gt; 
-            <a href="https://github.com/{{ repo }}/issues/{{ a.gnum }}">G{{ a.gnum }}</a></td>
-            <td align="center">{{ a.zuser }}</td>
-            <td align="center">{{ a.zdate }}</td>
-            <td align="center">{{ a.guser }}</td>
-            <td align="center">
-            {% if a.glabels %}
-                {% for b in a.glabels %}
-                    {{ b }},
+				<td>
+					<a class="open" href="{{ zen_url }}/tickets/
+					{{ a.z_id }}">Z{{ a.z_id }}</a> --&gt; 
+					<a class="open" href="{{ a.g_url }}">G{{ a.g_id }}</a>
+				</td>
+            <td>{{ a.z_user }}</td>
+            <td class="open">{{ a.z_date }}</td>
+			<td>{{ a.g_user }}</td>
+			<td class="open">{{ a.g_date }}</td>
+            <td>
+            {% if a.g_labels %}
+                {% for l in a.g_labels %}
+                    {{ l }},
                 {% endfor %}
             {% else %}
                 None
             {% endif %}
             </td>
-            <td align="center">
-                <span style="color:red">Closed ({{ a.gdate }})</span>
-            </td>
         {% endfor %}
         </table>
     {% else %}
-        <p align="center">There are currently no Associations ready to be closed.</p>
+        <p align="center">There are currently open Associations</p>
     {% endif %}
     <br/>
 
-    <h3>Open Associations</h3>
-    {% if o_assocs %}
+    <h3>Half Open Associations</h3>
+    {% if ho_assocs %}
         <table align="center" style="width:75%">
-        <tr>
-        <th>Association</th>
-        <th>Zendesk User</th>
-        <th>Last Zen Ticket Update</th>
-        <th>GitHub User</th>
-        <th>Git Issue Labels</th>
-        <th>Git Status</th>
-        </tr>
-        {% for a in o_assocs %}
+			<tr>
+				<th>Association</th>
+				<th>Zendesk User</th>
+				<th>Last Zen Ticket Update</th>
+				<th>GitHub User</th>
+				<th>Last Git Ticket Update</th>
+				<th>Git Issue Labels</th>
+			</tr>
+        {% for a in ho_assocs %}
             <tr>
-            <td align="center"><a href="{{ zen_url }}/tickets/{{ a.znum }}?col={{ zen_viewid }}">Z{{ a.znum }}</a> --&gt; 
+            	<td><a href="{{ zen_url }}/tickets/{{ a.znum }}?col={{ zen_viewid }}">Z{{ a.znum }}</a> --&gt; 
             <a href="https://github.com/{{ repo }}/issues/{{ a.gnum }}">G{{ a.gnum }}</a></td>
             <td align="center">{{ a.zuser }}</td>
             <td align="center">{{ a.zdate }}</td>

--- a/associations/templates/associations/home.html
+++ b/associations/templates/associations/home.html
@@ -73,10 +73,14 @@
 			<td>{{ a.g_user }}</td>
 			<td class="open">{{ a.g_date }}</td>
             <td>
-            {% if a.g_labels %}
-                {% for l in a.g_labels %}
-                    {{ l }},
-                {% endfor %}
+			{% if a.g_labels %}
+				{% for l in a.g_labels %}
+					{% if not forloop.last %}
+						{{ l }},
+					{% else %}
+						{{ l }}
+					{% endif %}
+				{% endfor %}
             {% else %}
                 None
             {% endif %}
@@ -105,11 +109,11 @@
 				{% if a.closed == 'g' %}
 					<a class="open" href="{{ zen_url }}/tickets/
 						{{ a.z_id }}">Z{{ a.z_id }}</a> --&gt; 
-					<a class="closed" href="a.g_url">G{{ a.g_id }}</a>
+					<a class="closed" href="{{ a.g_url }}">G{{ a.g_id }}</a>
 				{% else %}
 					<a class="closed" href="{{ zen_url }}/tickets/
 						{{ a.z_id }}">Z{{ a.z_id }}</a> --&gt; 
-					<a class="open" href="a.g_url">G{{ a.g_id }}</a>
+					<a class="open" href="{{ a.g_url }}">G{{ a.g_id }}</a>
 				{% endif %}
 				</td>
 				<td>{{ a.z_user }}</td>
@@ -127,7 +131,11 @@
 				<td>
 				{% if a.g_labels %}
 					{% for l in a.g_labels %}
-						{{ l }},
+						{% if not forloop.last %}
+							{{ l }},
+						{% else %}
+							{{ l }}
+						{% endif %}
 					{% endfor %}
 				{% else %}
 					None
@@ -141,7 +149,7 @@
     {% endif %}
     <br/>
 
-    <h3>Not Associated with GitHub</h3>
+    <h3>New Tickets not Associated with GitHub</h3>
     {% if no_assocs %}
         <table align="center" style="width:50%">
 			<tr>
@@ -171,6 +179,9 @@
 {% endif %}
 
 <!--
+
+TODO: Update the Quick Reference tables within this comment so that they work
+with the changes made in the code.
 
 <br/><br/>
 

--- a/associations/templates/associations/login.html
+++ b/associations/templates/associations/login.html
@@ -72,23 +72,18 @@
         {{ newform.zen_name }}
 	</div>
 	<div class="fieldWrapper">
-        {{ newform.zen_pass.errors }}
-        <label for="id_zen_pass">Zendesk Password:</label>
-        {{ newform.zen_pass }}
+        {{ newform.zen_token.errors }}
+        <label for="id_zen_token">Zendesk API Token:</label>
+        {{ newform.zen_token }}
     </div>
     <div class="fieldWrapper">
         {{ newform.zen_url.errors }}
         <label for="id_zen_url">Zendesk URL:</label>
         {{ newform.zen_url }}
     </div>
-    <div class="fieldWrapper">
-        {{ newform.zen_viewid.errors }}
-        <label for="id_zen_viewid">Zendesk Ticket View ID:</label>
-        {{ newform.zen_viewid }}
-	</div>
 	<div class="fieldWrapper">
 		{{ newform.zen_fieldid.errors }}
-		<label for="id_zen_fieldid">Zendesk Ticket Association Field:</label>
+		<label for="id_zen_fieldid">Zendesk Ticket Association Field ID:</label>
 		{{ newform.zen_fieldid }}
 	</div>
     <p><input name="new" type="submit" value="Create User" /></p>

--- a/associations/templates/associations/login.html
+++ b/associations/templates/associations/login.html
@@ -52,14 +52,19 @@
         {{ newform.git_name }}
     </div>
     <div class="fieldWrapper">
+        {{ newform.git_pass.errors }}
+        <label for="id_git_pass">GitHub Password:</label>
+        {{ newform.git_pass }}
+	</div>
+    <div class="fieldWrapper">
+        {{ newform.git_org.errors }}
+        <label for="id_git_org">GitHub Organization:</label>
+        {{ newform.git_org }}
+    </div>
+    <div class="fieldWrapper">
         {{ newform.git_repo.errors }}
         <label for="id_git_repo">GitHub Repository:</label>
         {{ newform.git_repo }}
-    </div>
-    <div class="fieldWrapper">
-        {{ newform.git_key.errors }}
-        <label for="id_git_key">GitHub API Key:</label>
-        {{ newform.git_key }}
     </div>
     <div class="fieldWrapper">
         {{ newform.zen_name.errors }}
@@ -89,4 +94,5 @@
     <p><input name="new" type="submit" value="Create User" /></p>
 </form>
 
-
+</body>
+</html>

--- a/associations/views.py
+++ b/associations/views.py
@@ -319,11 +319,11 @@ def home(request):
         ticket_nums = [i['number'] for i in git_tics]
 
     if working['git'] and working['zen']:
-        c_assocs = []
-        o_assocs = []
-        no_assocs = []
-        working['c_assocs'] = True
+        o_assocs = [] # open associations
+        ho_assocs = [] # half-open associations
+        no_assocs = [] # no associations
         working['o_assocs'] = True
+        working['ho_assocs'] = True
         working['no_assocs'] = True
 
         for t in zen_tics_full:
@@ -349,9 +349,10 @@ def home(request):
                     if i['number'] == int(a_num.split('-')[1]):
                         git_issue = i
                         break
-                a_data['g_is'] = git_issue['number']
+                a_data['g_id'] = git_issue['number']
                 a_data['g_user'] = git_issue['user']['login']
                 a_data['g_labels'] = [i['name'] for i in git_issue['labels']]
+                a_data['g_url'] = git_issue['html_url']
                 a_data['g_status'] = git_issue['state']
                 
                 if a_data['g_status'] == 'open' and \
@@ -375,15 +376,15 @@ def home(request):
                         a_data['closed'] = 'z'
                     else:
                         a_data['closed'] = 'g'
-                    c_assocs.append(a_data)
+                    ho_assocs.append(a_data)
     else:
-        working['c_assocs'] = False
         working['o_assocs'] = False
+        working['ho_assocs'] = False
         working['no_assocs'] = False
         
     return render_to_response('associations/home.html', {'git_tics': git_tics,
                                 'zen_tics': zen_tics, 'zen_users': zen_users, 
-                                'c_assocs': c_assocs, 'o_assocs': o_assocs,
+                                'ho_assocs': c_assocs, 'o_assocs': o_assocs,
                                 'no_assocs': no_assocs, 'repo': user.git_repo, 
                                 'zen_url': user.zen_url, 'working': working},
                                 context_instance=RequestContext(request))

--- a/associations/views.py
+++ b/associations/views.py
@@ -178,8 +178,8 @@ def home(request):
                         org_name = o['name']
                         break
 
-            zen_users.append({'name': u['name']
-                        'email': u['email']
+            zen_users.append({'name': u['name'],
+                        'email': u['email'],
                         'id': u['id'],
                         'org_name': org_name})
     else:

--- a/associations/views.py
+++ b/associations/views.py
@@ -73,7 +73,6 @@ def user_login(request):
                     user.git_org = data['git_org']
                     user.git_repo = data['git_repo']
                     user.zen_name = data['zen_name']
-                    user.zen_name += '/token'
                     user.zen_token = data['zen_token']
                     user.zen_url = data['zen_url']
                     user.zen_fieldid = data['zen_fieldid']
@@ -139,10 +138,12 @@ def home(request):
         working['git'] = False
 
     try:
+        zen_name_tk = user.zen_name + '/token' #Zen user email set up for
+                                               #API token authorization
         zticket_list = []
         url = '%s/api/v2/tickets.json' % (user.zen_url)
         while True:
-            r_zt = requests.get(url, auth=(user.zen_name, user.zen_token))
+            r_zt = requests.get(url, auth=(zen_name_tk, user.zen_token))
             zticket_list.extend(r_zt.json['tickets'])
             if r_zt.json['next_page'] is not None:
                 url = r_zt.json['next_page']
@@ -152,7 +153,7 @@ def home(request):
         zuser_list = []
         url = '%s/api/v2/users.json' % (user.zen_url)
         while True:
-            r_zu = requests.get(url, auth=(user.zen_name, user.zen_token))
+            r_zu = requests.get(url, auth=(zen_name_tk, user.zen_token))
             zuser_list.extend(r_zu.json['users'])
             if r_zu.json['next_page'] is not None:
                 url = r_zu.json['next_page']
@@ -162,7 +163,7 @@ def home(request):
         zorg_list = []
         url = '%s/api/v2/organizations.json' % (user.zen_url)
         while True:
-            r_zo = requests.get(url, auth=(user.zen_name, user.zen_token))
+            r_zo = requests.get(url, auth=(zen_name_tk, user.zen_token))
             zorg_list.extend(r_zo.json['organizations'])
             if r_zo.json['next_page'] is not None:
                 url = r_zo.json['next_page']
@@ -170,7 +171,6 @@ def home(request):
                 break
         
         working['zen'] = True
-        'break' == 1
     except:
         working['zen'] = False
          

--- a/associations/views.py
+++ b/associations/views.py
@@ -101,15 +101,13 @@ def confirm(request, con_num):
 
 def home(request):
     user = request.user
-    git_tics = ''
-    zen_tics = ''
 
     try:
-        r_op = requests.get('https://api.github.com/users/%s/%s/issues' %
+        r_op = requests.get('https://api.github.com/repos/%s/%s/issues' %
                             (user.git_org, user.git_repo),
                             params={'state': 'open'},
                             auth=(user.git_name, user.git_pass))
-        r_cl = requests.get('https://api.github.com/users/%s/%s/issues' %
+        r_cl = requests.get('https://api.github.com/repos/%s/%s/issues' %
                             (user.git_org, user.git_repo),
                             params={'state': 'closed'},
                             auth=(user.git_name, user.git_pass))
@@ -117,7 +115,7 @@ def home(request):
         gopen_list = r_op.json
         gclosed_list = r_cl.json
 
-        if type(r_op.text) is type({}) and "message" in r_op.text:
+        if "message" in gopen_list:
             git_tics = 'broken'
     except:
         git_tics = 'broken'
@@ -134,7 +132,7 @@ def home(request):
         zuser_list = r_zu.json['users']
         zorg_list = r_zo.json['organizations']
 
-        if type(r_zt.text) is type({}) and "message" in r_zt.text:
+        if "message" in zticket_list:
             zen_tics = 'broken'
     except:
         zen_tics = 'broken'
@@ -186,6 +184,7 @@ def home(request):
         zen_users = 'broken'
     
     if git_tics != 'broken':
+        git_tics = []
         on_zen = []
         for t in zen_tics_full:
             a_num = [f for f in t['fields'] if f['id'] == \
@@ -196,7 +195,7 @@ def home(request):
         for t in gclosed_list:
             if t['number'] in on_zen:
                 git_tics.append(t)
-        git_tics += gopen_list
+        git_tics.extend(gopen_list)
         ticket_nums = [i['number'] for i in git_tics]
 
     if git_tics != 'broken' and zen_tics != 'broken':

--- a/associations/views.py
+++ b/associations/views.py
@@ -3,11 +3,11 @@ from django.template import RequestContext
 from django.shortcuts import render_to_response
 from django.contrib.auth import authenticate, login, logout
 from django import forms
-from github2.client import Github
-from github2.issues import *
 from zendesk import Zendesk
 from xml.dom import minidom
 from associations.models import GZUser
+import requests
+import json
 
 class LogForm(forms.Form):
     username = forms.CharField(max_length=75)
@@ -18,8 +18,9 @@ class NewForm(forms.Form):
     password = forms.CharField(max_length=75, widget=forms.PasswordInput)
     affirmpass = forms.CharField(max_length=75, widget=forms.PasswordInput)
     git_name = forms.CharField(max_length=75)
+    git_pass = forms.CharField(max_length=75, widget=forms.PasswordInput)
+    git_org = forms.CharField(max_length=75)
     git_repo = forms.CharField(max_length=75)
-    git_key = forms.CharField(max_length=75)
     zen_name = forms.CharField(max_length=75)
     zen_pass = forms.CharField(max_length=75, widget=forms.PasswordInput)
     zen_url = forms.CharField(max_length=100)
@@ -28,17 +29,20 @@ class NewForm(forms.Form):
 
 class ChangeForm(forms.Form):
     old_pass = forms.CharField(max_length=75, widget=forms.PasswordInput,
-                                required=False)
-    new_pass = forms.CharField(max_length=75, widget=forms.PasswordInput, 
-                                required=False)
-    aff_pass = forms.CharField(max_length=75, widget=forms.PasswordInput, 
-                                required=False)
+                               required=False)
+    new_pass = forms.CharField(max_length=75, widget=forms.PasswordInput,
+                               required=False)
+    aff_pass = forms.CharField(max_length=75, widget=forms.PasswordInput,
+                               required=False)
     git_name = forms.CharField(max_length=75, required=False)
+    git_pass = forms.CharField(max_length=75, widget=forms.PasswordInput, 
+                               required=False)
+    git_org = forms.CharField(max_length=75, required=False)
     git_repo = forms.CharField(max_length=75, required=False)
     git_key = forms.CharField(max_length=75, required=False)
     zen_name = forms.CharField(max_length=75, required=False)
-    zen_pass = forms.CharField(max_length=75, widget=forms.PasswordInput, 
-                                required=False)
+    zen_pass = forms.CharField(max_length=75, widget=forms.PasswordInput,
+                               required=False)
     zen_url = forms.CharField(max_length=100, required=False)
     zen_viewid = forms.CharField(max_length=25, required=False)
     zen_fieldid = forms.CharField(max_length=50, required=False)
@@ -71,8 +75,9 @@ def user_login(request):
                         email='',
                     )
                     user.git_name = data['git_name']
+                    user.git_pass = data['git_pass']
+                    user.git_org = data['git_org']
                     user.git_repo = data['git_repo']
-                    user.git_key = data['git_key']
                     user.zen_name = data['zen_name']
                     user.zen_pass = data['zen_pass']
                     user.zen_url = data['zen_url']
@@ -106,9 +111,10 @@ def home(request):
     zenTics = ''
 
     try:
-        github = Github(username=user.git_name, 
-                    api_token=user.git_key)
-        repo = user.git_repo
+        r = requests.get('https://api.github.com/users/%s/%s/issues' %
+                         (user.git_org, user.git_repo), auth=(user.git_name,
+                                                              user.git_pass))
+        if r.text
     except:
         gitTics = 'broken'
 
@@ -220,10 +226,12 @@ def change(request):
                     return HttpResponseRedirect('/nope/3')
             if data['git_name']:
                 user.git_name = data['git_name']
+            if data['git_pass']:
+                user.git_key = data['git_pass']
+            if data['git_org']:
+                user.git_key = data['git_org']
             if data['git_repo']:
                 user.git_repo = data['git_repo']
-            if data['git_key']:
-                user.git_key = data['git_key']
             if data['zen_name']:
                 user.zen_name = data['zen_name']
             if data['zen_pass']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ psycopg2==2.4.5
 dj-database-url==0.2.0
 requests==0.13.0
 pycrypto==2.6
+django_evolution==0.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ django==1.3.1
 psycopg2==2.4.5
 dj-database-url==0.2.0
 requests==0.13.0
-zendesk==1.0.0
 pycrypto==2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ psycopg2==2.4.5
 dj-database-url==0.2.0
 requests==0.13.0
 pycrypto==2.6
+south==0.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django==1.3.1
 psycopg2==2.4.5
 dj-database-url==0.2.0
-github2==0.6.1
+requests==0.13.0
 zendesk==1.0.0
 pycrypto==2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ psycopg2==2.4.5
 dj-database-url==0.2.0
 requests==0.13.0
 pycrypto==2.6
-south==0.7.5
+django_evolution==0.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ psycopg2==2.4.5
 dj-database-url==0.2.0
 requests==0.13.0
 pycrypto==2.6
-django_evolution==0.6.7

--- a/settings.py
+++ b/settings.py
@@ -13,6 +13,13 @@ MANAGERS = ADMINS
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(PROJECT_ROOT, '..', 'gitzen.db'),
+    }
+}
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
@@ -114,7 +121,7 @@ INSTALLED_APPS = (
 )
 
 AUTHENTICATION_BACKENDS = (
-    'associations.auth_backends.GZUserModelBackend',
+    'gitzen.associations.auth_backends.GZUserModelBackend',
 )
 
 CUSTOM_USER_MODEL = 'associations.GZUser'

--- a/settings.py
+++ b/settings.py
@@ -149,7 +149,7 @@ LOGGING = {
     }
 }
 
-#import dj_database_url
-#DATABASES = {
-#    'default': dj_database_url.config(default='postgres://localhost')
-#    }
+import dj_database_url
+DATABASES = {
+    'default': dj_database_url.config(default='postgres://localhost')
+    }

--- a/settings.py
+++ b/settings.py
@@ -115,7 +115,7 @@ INSTALLED_APPS = (
 )
 
 AUTHENTICATION_BACKENDS = (
-    'gitzen.associations.auth_backends.GZUserModelBackend',
+    'associations.auth_backends.GZUserModelBackend',
 )
 
 CUSTOM_USER_MODEL = 'associations.GZUser'

--- a/settings.py
+++ b/settings.py
@@ -113,8 +113,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'associations',
-    'django_evolution'
+    'associations'
     # Uncomment the next line to enable the admin:
     # 'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:

--- a/settings.py
+++ b/settings.py
@@ -13,13 +13,6 @@ MANAGERS = ADMINS
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(PROJECT_ROOT, '..', 'gitzen.db'),
-    }
-}
-
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.

--- a/settings.py
+++ b/settings.py
@@ -13,6 +13,13 @@ MANAGERS = ADMINS
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(PROJECT_ROOT, '..', 'gitzen.db')
+    }
+}
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
@@ -143,7 +150,7 @@ LOGGING = {
     }
 }
 
-import dj_database_url
-DATABASES = {
-    'default': dj_database_url.config(default='postgres://localhost')
-    }
+#import dj_database_url
+#DATABASES = {
+#    'default': dj_database_url.config(default='postgres://localhost')
+#    }

--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,6 @@
 # Django settings for gitzen project.
 
 import os.path
-import dj_database_url
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
@@ -13,10 +12,6 @@ ADMINS = (
 MANAGERS = ADMINS
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
-
-DATABASES = {
-    'default': dj_database_url.config(default='postgres://localhost')
-    }
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -146,3 +141,8 @@ LOGGING = {
         },
     }
 }
+
+import dj_database_url
+DATABASES = {
+    'default': dj_database_url.config(default='postgres://localhost')
+    }

--- a/settings.py
+++ b/settings.py
@@ -107,7 +107,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'associations',
-    'south'
+    'django_evolution'
     # Uncomment the next line to enable the admin:
     # 'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:

--- a/settings.py
+++ b/settings.py
@@ -106,7 +106,8 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'associations'
+    'associations',
+    'south'
     # Uncomment the next line to enable the admin:
     # 'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:

--- a/settings.py
+++ b/settings.py
@@ -106,8 +106,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'associations',
-    'django_evolution'
+    'associations'
     # Uncomment the next line to enable the admin:
     # 'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:


### PR DESCRIPTION
A significant portion of the code was rewritten to convert it from the no longer supported versions of the GitHub and Zendesk APIs to their modern versions. The API calls were also tested to insure that they worked as expected. Since the new APIs require some different information as access parameters, the database models for the application were also modified to meet these new requirements. Finally, the README file has also been updated with documentation on how to configure a GitZen account.

After these initial changes were made, I made several refactoring changes in the core code of the application in the "views.py" file that fixed several small issues and improved the structure of the code. This included breaking the previously huge function `home` into three more manageable parts (`api_calls`, `filter_lists`, and `build_associations`), adjusting the API calls to receive all of the necessary data by accounting for pagination, and converting dates to a more readable format for display. In addition, I added much more comments throughout the code to describe the various functions and code blocks.

Finally, I modified the template of the home page of the application found in the file "home.html" to restore basic functionality to the app. This home page now displays the three main tables ("Open Associations", "Half-open Associations", and "No Associations") with the correct data in a readable format, but the overall design of the page is still lacking in both functionality and interface design. My next task will probably be to continue working with this template to improve this design.
