### PR TITLE
gz-5: Reduced load time of home page so that it will load on Heroku

### DIFF
--- a/associations/templates/associations/home.html
+++ b/associations/templates/associations/home.html
@@ -178,11 +178,6 @@
     Zendesk. Try adjusting your account settings.</p>
 {% endif %}
 
-<br/>
-<p align="center">{{ times.api }}</p>
-<p align="center">{{ times.filter }}</p>
-<p align="center">{{ times.build }}</p>
-
 <!--
 
 TODO: Update the Quick Reference tables within this comment so that they work

--- a/associations/templates/associations/home.html
+++ b/associations/templates/associations/home.html
@@ -88,7 +88,7 @@
         {% endfor %}
         </table>
     {% else %}
-        <p align="center">There are currently open Associations</p>
+        <p align="center">There are currently no open Associations</p>
     {% endif %}
     <br/>
 

--- a/associations/templates/associations/home.html
+++ b/associations/templates/associations/home.html
@@ -178,6 +178,11 @@
     Zendesk. Try adjusting your account settings.</p>
 {% endif %}
 
+<br/>
+<p align="center">{{ times.api }}</p>
+<p align="center">{{ times.filter }}</p>
+<p align="center">{{ times.build }}</p>
+
 <!--
 
 TODO: Update the Quick Reference tables within this comment so that they work

--- a/associations/templates/associations/home.html
+++ b/associations/templates/associations/home.html
@@ -178,12 +178,6 @@
     Zendesk. Try adjusting your account settings.</p>
 {% endif %}
 
-</br>
-<p>Git open: {{ times.go }}</p>
-<p>Git closed: {{ times.gc }}</p>
-<p>Zen tickets: {{ times.zt }}</p>
-<p>Zen users: {{ times.zu }}</p>
-
 <!--
 
 TODO: Update the Quick Reference tables within this comment so that they work

--- a/associations/templates/associations/home.html
+++ b/associations/templates/associations/home.html
@@ -178,6 +178,12 @@
     Zendesk. Try adjusting your account settings.</p>
 {% endif %}
 
+</br>
+<p>Git open: {{ times.go }}</p>
+<p>Git closed: {{ times.gc }}</p>
+<p>Zen tickets: {{ times.zt }}</p>
+<p>Zen users: {{ times.zu }}</p>
+
 <!--
 
 TODO: Update the Quick Reference tables within this comment so that they work

--- a/associations/views.py
+++ b/associations/views.py
@@ -6,11 +6,6 @@ from django import forms
 from associations.models import GZUser
 import requests
 from datetime import datetime, timedelta
-<<<<<<< HEAD
-from time import strptime, mktime
-=======
-from time import time
->>>>>>> ff1306c62ccdc4cf81ad4e3779e78d2256cc90d9
 
 class LogForm(forms.Form):
     """Form for login of an existing user."""
@@ -219,7 +214,6 @@ def home(request):
     # Add additional user data to be rendered to the home page
     render_data['repo'] = request.user.git_repo
     render_data['zen_url'] = request.user.zen_url
-    render_data['times'] = api_lists['times']
     
     return render_to_response('associations/home.html', render_data,
                                 context_instance=RequestContext(request))
@@ -246,7 +240,6 @@ def api_calls(request):
 
     try:  # GitHub API calls to get all open and closed tickets
         # Get GitHub open tickets
-        go_start = time()
         gopen_list = []
         page = 1
         url = 'https://api.github.com/repos/%s/%s/issues?page=%s' % \
@@ -261,9 +254,7 @@ def api_calls(request):
                             (user.git_org, user.git_repo, page)
             else:
                 break
-        go_time = time() - go_start
         # Get GitHub closed tickets
-        gc_start = time()
         gclosed_list = []
         page = 1
         url = 'https://api.github.com/repos/%s/%s/issues?page=%s' % \
@@ -317,8 +308,7 @@ def api_calls(request):
         'gclosed': gclosed_list,
         'ztickets': zticket_list,
         'zusers': zuser_list,
-        'status': working,
-        'times': times
+        'status': working
     }
 
     return api_lists

--- a/associations/views.py
+++ b/associations/views.py
@@ -74,7 +74,7 @@ def user_login(request):
 
                 if user is not None:
                     login(request, user)
-                    return HttpResponseRedirect('/main/')
+                    return HttpResponseRedirect('/home/')
                 else:
                     return HttpResponseRedirect('/nope/1/')
             newform = NewForm()

--- a/associations/views.py
+++ b/associations/views.py
@@ -272,6 +272,8 @@ def api_calls(request):
 
         working['git'] = True
     except:
+        gopen_list = []
+        gclosed_list = []
         working['git'] = False
 
     try:  # Zendesk API calls to get all tickets and users
@@ -301,6 +303,8 @@ def api_calls(request):
 
         working['zen'] = True
     except:
+        zticket_list = []
+        zuser_list = []
         working['zen'] = False
     
     api_lists = {

--- a/associations/views.py
+++ b/associations/views.py
@@ -6,7 +6,7 @@ from django import forms
 from associations.models import GZUser
 import requests
 from datetime import datetime, timedelta
-import time from time
+from time import time
 
 class LogForm(forms.Form):
     """Form for login of an existing user."""

--- a/associations/views.py
+++ b/associations/views.py
@@ -243,8 +243,6 @@ def api_calls(request):
     """
     user = request.user
     working = {}
-    date_limit = datetime.now() - timedelta(days=180)
-    limit_str = datetime.strftime(date_limit, '%Y-%m-%dT%H:%M:%SZ')
 
     try:  # GitHub API calls to get all open and closed tickets
         # Get GitHub open tickets
@@ -254,9 +252,8 @@ def api_calls(request):
         url = 'https://api.github.com/repos/%s/%s/issues?page=%s' % \
                             (user.git_org, user.git_repo, page)
         while True:
-            r_op = requests.get(url,
-                                params={'state': 'open', 'since': limit_str}, 
-                                auth=(user.git_name, user.git_pass))
+            r_op = requests.get(url, params={'state': 'open'},
+                            auth=(user.git_name, user.git_pass))
             gopen_list.extend(r_op.json)
             if r_op.json:
                 page += 1
@@ -272,9 +269,8 @@ def api_calls(request):
         url = 'https://api.github.com/repos/%s/%s/issues?page=%s' % \
                             (user.git_org, user.git_repo, page)
         while True:
-            r_cl = requests.get(url, 
-                                params={'state': 'closed', 'since': limit_str},
-                                auth=(user.git_name, user.git_pass))
+            r_cl = requests.get(url, params={'state': 'closed'},
+                            auth=(user.git_name, user.git_pass))
             gclosed_list.extend(r_cl.json)
             if r_cl.json:
                 page += 1

--- a/associations/views.py
+++ b/associations/views.py
@@ -212,7 +212,7 @@ def home(request):
     build_start = time()
     render_data = build_associations(request.user.zen_fieldid, filtered_lists,
                                     api_status)
-    build_time = time() - build_start()
+    build_time = time() - build_start
 
     # Combine the status dictionaries from the API data and association lists
     render_data['status'] = dict(render_data['status'].items() +

--- a/associations/views.py
+++ b/associations/views.py
@@ -237,6 +237,8 @@ def api_calls(request):
     """
     user = request.user
     working = {}
+    date_limit = datetime.now() - timedelta(days=180)
+    limit_str = datetime.strftime(date_limit, '%Y-%m-%dT%H:%M:%SZ')
 
     try:  # GitHub API calls to get all open and closed tickets
         # Get GitHub open tickets
@@ -245,8 +247,9 @@ def api_calls(request):
         url = 'https://api.github.com/repos/%s/%s/issues?page=%s' % \
                             (user.git_org, user.git_repo, page)
         while True:
-            r_op = requests.get(url, params={'state': 'open'},
-                            auth=(user.git_name, user.git_pass))
+            r_op = requests.get(url,
+                                params={'state': 'open', 'since': limit_str}, 
+                                auth=(user.git_name, user.git_pass))
             gopen_list.extend(r_op.json)
             if r_op.json:
                 page += 1
@@ -261,8 +264,9 @@ def api_calls(request):
         url = 'https://api.github.com/repos/%s/%s/issues?page=%s' % \
                             (user.git_org, user.git_repo, page)
         while True:
-            r_cl = requests.get(url, params={'state': 'closed'},
-                            auth=(user.git_name, user.git_pass))
+            r_cl = requests.get(url, 
+                                params={'state': 'closed', 'since': limit_str},
+                                auth=(user.git_name, user.git_pass))
             gclosed_list.extend(r_cl.json)
             if r_cl.json:
                 page += 1

--- a/associations/views.py
+++ b/associations/views.py
@@ -6,7 +6,6 @@ from django import forms
 from associations.models import GZUser
 import requests
 from datetime import datetime, timedelta
-from time import time
 
 class LogForm(forms.Form):
     """Form for login of an existing user."""
@@ -201,18 +200,12 @@ def home(request):
     filtered_lists = {} # Stores lists of the filtered API data
     render_data = {} # Data to be rendered to the home page
     
-    api_start = time()
     api_lists = api_calls(request)
-    api_time = time() - api_start
-    filter_start = time()
     filtered_lists = filter_lists(request.user.zen_fieldid, api_lists)
-    filter_time = time() - filter_start
 
     api_status = api_lists['status']['git'] and api_lists['status']['zen']
-    build_start = time()
     render_data = build_associations(request.user.zen_fieldid, filtered_lists,
                                     api_status)
-    build_time = time() - build_start
 
     # Combine the status dictionaries from the API data and association lists
     render_data['status'] = dict(render_data['status'].items() +
@@ -221,11 +214,6 @@ def home(request):
     # Add additional user data to be rendered to the home page
     render_data['repo'] = request.user.git_repo
     render_data['zen_url'] = request.user.zen_url
-    render_data['times'] = {
-        'api': api_time,
-        'filter': filter_time,
-        'build': build_time
-    }
     
     return render_to_response('associations/home.html', render_data,
                                 context_instance=RequestContext(request))

--- a/settings.py
+++ b/settings.py
@@ -149,7 +149,7 @@ LOGGING = {
     }
 }
 
-#import dj_database_url
-#DATABASES = {
-#    'default': dj_database_url.config(default='postgres://localhost')
-#    }
+import dj_database_url
+DATABASES = {
+    'default': dj_database_url.config(default='postgres://localhost')
+    }

--- a/settings.py
+++ b/settings.py
@@ -149,7 +149,7 @@ LOGGING = {
     }
 }
 
-import dj_database_url
-DATABASES = {
-    'default': dj_database_url.config(default='postgres://localhost')
-    }
+#import dj_database_url
+#DATABASES = {
+#    'default': dj_database_url.config(default='postgres://localhost')
+#    }

--- a/urls.py
+++ b/urls.py
@@ -6,7 +6,7 @@ from django.conf.urls.defaults import patterns, include, url
 
 urlpatterns = patterns('associations.views',
     (r'^$', 'user_login'),
-    (r'^main/$', 'home'),
+    (r'^home/$', 'home'),
     (r'^change/$', 'change'),
     (r'^nope/(?P<nope_num>\d+)/$', 'nope'),
     (r'^confirm/(?P<con_num>\d+)/$', 'confirm'),


### PR DESCRIPTION
After fixing the API calls in the application so that they gathered all of the tickets from Zendesk and GitHub, the app became extremely slow because it took a large number of http requests to gather all of this data from each website. In order for the app to run successfully on Heroku's servers, it must be able to load the home page in under 30 seconds, and because of these requests, the application could not load fast enough.

My solution to this problem was to limit the API calls to only gathering data from the last 6 months in order to cut out a large portion of the data requested from each website. Any data older than 6 months will probably not be useful in the app, so it should not be much of a loss excluding it. After testing, I confirmed that these limits allow the home page to load fast enough to run on Heroku.

An issue with this solution is that it requires me to hard-code the page number to start the Zendesk ticket API calls on based off looking at the data returned by these calls. This is the only way I could filter the requests to the Zendesk API by date. I could ask the user to find this information and store it under their account, but it is a rather annoying piece of information to find, so that may not be a feasible solution. Either way, I will probably have to address this issue sometime in the future.

(Also, I had a few issues with my commits during this ticket that I have now resolved, but I apologize if the commits appear a little sloppy.)
