### PR TITLE
gz-7: API calls are now optimized so that they request the correct tickets and allow the user to set the date range

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,16 @@ dictionary as this "value" pair, the number value for the "id" key is the ID
 number that must be entered into the "Zendesk Ticket Association Field ID" field
 in the new user form.
 
-8. Check to see that all fields under the "New User" heading are filled out
+8. For the "Age Limit (in days) for the Tickets" field in the new user form,
+enter a limit (in days) for the age of the tickets used in the application.
+Only tickets from Zendesk and GitHub that were last updated between the current
+time and this age limit away from the current time will be monitored in the
+application. It should be noted that the higher this age limit is set, the
+longer it will take to load the application on login, so for this reason, it is
+recommended that the age limit is not set higher than one year (365 days) to
+avoid load times that are too long for Heroku. 
+
+9. Check to see that all fields under the "New User" heading are filled out
 accurately, and then click the "Create User" button to create a user with the
 given information. A confirmation page should come up after this process that
 will have a link to return to the login screen.
-

--- a/enhancement_tracking/forms.py
+++ b/enhancement_tracking/forms.py
@@ -1,0 +1,41 @@
+from django.forms import Form, CharField, IntegerField, PasswordInput
+
+class LogForm(Form):
+    """Form for login of an existing user."""
+    
+    username = CharField(max_length=75)
+    password = CharField(max_length=75, widget=PasswordInput)
+
+class NewForm(Form):
+    """Form for creating a new user."""
+    
+    username = CharField(max_length=75)
+    password = CharField(max_length=75, widget=PasswordInput)
+    affirmpass = CharField(max_length=75, widget=PasswordInput)
+    git_name = CharField(max_length=75)
+    git_pass = CharField(max_length=75, widget=PasswordInput)
+    git_org = CharField(max_length=75)
+    git_repo = CharField(max_length=75)
+    zen_name = CharField(max_length=75)
+    zen_token = CharField(max_length=75, widget=PasswordInput)
+    zen_url = CharField(max_length=100)
+    zen_fieldid = CharField(max_length=50)
+    age_limit = IntegerField() 
+
+
+class ChangeForm(Form):
+    """Form for changing the data of an existing user. Does not use ModelForm
+    because all of the fields need to be set as not required."""
+
+    old_pass = CharField(max_length=75, widget=PasswordInput, required=False)
+    new_pass = CharField(max_length=75, widget=PasswordInput, required=False)
+    aff_pass = CharField(max_length=75, widget=PasswordInput, required=False)
+    git_name = CharField(max_length=75, required=False)
+    git_pass = CharField(max_length=75, widget=PasswordInput, required=False)
+    git_org = CharField(max_length=75, required=False)
+    git_repo = CharField(max_length=75, required=False)
+    zen_name = CharField(max_length=75, required=False)
+    zen_token = CharField(max_length=75, widget=PasswordInput, required=False)
+    zen_url = CharField(max_length=100, required=False)
+    zen_fieldid = CharField(max_length=50, required=False)
+    age_limit = IntegerField(required=False)

--- a/enhancement_tracking/models.py
+++ b/enhancement_tracking/models.py
@@ -11,5 +11,6 @@ class GZUser(User):
     zen_token = EncryptedCharField(max_length=75)
     zen_url = models.CharField(max_length=100)
     zen_fieldid = models.CharField(max_length=50)
+    age_limit = models.IntegerField(null=True)
 
     objects = UserManager()

--- a/enhancement_tracking/templates/change.html
+++ b/enhancement_tracking/templates/change.html
@@ -67,6 +67,11 @@ User password.</p>
 		<label for="id_zen_fieldid">Zendesk Ticket Association Field ID:</label>
 		{{ changeform.zen_fieldid }}
 	</div>
+	<div class="fieldWrapper">
+		{{ changeform.age_limit.errors }}
+		<label for="id_age_limit">Age Limit (in days) for the Tickets:</label>
+		{{ changeform.age_limit }}
+	</div>
     <p><input name="change" type="submit" value="Submit Changes" /></p>
 </form>
 

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -117,7 +117,7 @@
 </div>
 </div>
 
-    <h3>Recent Requested Enhancements not Associated with GitHub</h3>
+    <h3>Requested Enhancements not Associated with GitHub</h3>
     {% if not_tracking %}
 		<table class="table table-striped center" style="width:50%">
 			<thead>

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -117,7 +117,7 @@
 </div>
 </div>
 
-    <h3>Requested Enhancements not Associated with GitHub</h3>
+    <h3>Recent Requested Enhancements not Associated with GitHub</h3>
     {% if not_tracking %}
 		<table class="table table-striped center" style="width:50%">
 			<thead>

--- a/enhancement_tracking/templates/login.html
+++ b/enhancement_tracking/templates/login.html
@@ -83,6 +83,11 @@
 		<label for="id_zen_fieldid">Zendesk Ticket Association Field ID:</label>
 		{{ newform.zen_fieldid }}
 	</div>
+	<div class="fieldWrapper">
+		{{ newform.age_limit.errors }}
+		<label for="id_age_limit">Age Limit (in days) for the Tickets:</label>
+		{{ newform.age_limit }}
+	</div>
     <p><input name="new" type="submit" value="Create User" /></p>
 </form>
 

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -28,6 +28,7 @@ class NewForm(forms.Form):
     zen_token = forms.CharField(max_length=75, widget=forms.PasswordInput)
     zen_url = forms.CharField(max_length=100)
     zen_fieldid = forms.CharField(max_length=50)
+    age_limit = forms.IntegerField()
 
 class ChangeForm(forms.Form):
     """Form for changing the data of an existing user."""
@@ -48,6 +49,7 @@ class ChangeForm(forms.Form):
                                required=False)
     zen_url = forms.CharField(max_length=100, required=False)
     zen_fieldid = forms.CharField(max_length=50, required=False)
+    age_limit = forms.IntegerField(required=False)
 
 
 def user_login(request):
@@ -97,6 +99,7 @@ def user_login(request):
                     user.zen_token = data['zen_token']
                     user.zen_url = data['zen_url']
                     user.zen_fieldid = data['zen_fieldid']
+                    user.age_limit = data['age_limit']
                     user.save()
 
                     return HttpResponseRedirect(reverse('confirm', args=[1]))
@@ -152,6 +155,8 @@ def change(request):
                 user.zen_url = data['zen_url']
             if data['zen_fieldid']:
                 user.zen_fieldid = data['zen_fieldid']
+            if data['age_limit']:
+                user.age_limit = data['age_limit']
             user.save()
 
             return HttpResponseRedirect(reverse('confirm', args=[2]))
@@ -237,9 +242,9 @@ def api_calls(request):
     user = request.user
     working = {}
 
-    # These lines set the limit for how far back the API calls go when
-    # gathering tickets. Currently, this limit is 180 days.
-    date_limit = datetime.now() - timedelta(days=180)
+    # This line sets the limit for how far back the API calls go when
+    # gathering tickets.
+    date_limit = datetime.now() - timedelta(days=user.age_limit)
 
     # Git and Zen require the date_limit to be formatted differently
     git_limit_str = datetime.strftime(date_limit, '%Y-%m-%dT%H:%M:%SZ')

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -3,54 +3,10 @@ from django.template import RequestContext
 from django.shortcuts import render_to_response
 from django.contrib.auth import authenticate, login, logout
 from django.core.urlresolvers import reverse
-from django import forms
 from enhancement_tracking.models import GZUser
+from enhancement_tracking.forms import LogForm, NewForm, ChangeForm
 import requests
 from datetime import datetime, timedelta
-
-class LogForm(forms.Form):
-    """Form for login of an existing user."""
-
-    username = forms.CharField(max_length=75)
-    password = forms.CharField(max_length=75, widget=forms.PasswordInput)
-
-class NewForm(forms.Form):
-    """Form for creating a new user."""
-
-    username = forms.CharField(max_length=75)
-    password = forms.CharField(max_length=75, widget=forms.PasswordInput)
-    affirmpass = forms.CharField(max_length=75, widget=forms.PasswordInput)
-    git_name = forms.CharField(max_length=75)
-    git_pass = forms.CharField(max_length=75, widget=forms.PasswordInput)
-    git_org = forms.CharField(max_length=75)
-    git_repo = forms.CharField(max_length=75)
-    zen_name = forms.CharField(max_length=75)
-    zen_token = forms.CharField(max_length=75, widget=forms.PasswordInput)
-    zen_url = forms.CharField(max_length=100)
-    zen_fieldid = forms.CharField(max_length=50)
-    age_limit = forms.IntegerField()
-
-class ChangeForm(forms.Form):
-    """Form for changing the data of an existing user."""
-
-    old_pass = forms.CharField(max_length=75, widget=forms.PasswordInput,
-                               required=False)
-    new_pass = forms.CharField(max_length=75, widget=forms.PasswordInput,
-                               required=False)
-    aff_pass = forms.CharField(max_length=75, widget=forms.PasswordInput,
-                               required=False)
-    git_name = forms.CharField(max_length=75, required=False)
-    git_pass = forms.CharField(max_length=75, widget=forms.PasswordInput, 
-                               required=False)
-    git_org = forms.CharField(max_length=75, required=False)
-    git_repo = forms.CharField(max_length=75, required=False)
-    zen_name = forms.CharField(max_length=75, required=False)
-    zen_token = forms.CharField(max_length=75, widget=forms.PasswordInput,
-                               required=False)
-    zen_url = forms.CharField(max_length=100, required=False)
-    zen_fieldid = forms.CharField(max_length=50, required=False)
-    age_limit = forms.IntegerField(required=False)
-
 
 def user_login(request):
     """Processes the requests from the login page. 


### PR DESCRIPTION
The first major change in this ticket was adjusting the Zendesk API call to request only the tickets needed for the app by utilizing its search feature to filter by ticket type and date. In addition to this change, the API calls in general where optimized by using constants for the base URLs and moving all parameters to the requests get method to avoid unnecessary string manipulation.

The other major change in this ticket was allowing the user to configure the age limit for tickets used in the app instead of it being hard-coded. To achieve this, another field was added to the GZUser objects (age_limit). Also, the configuration instructions in the README were updated with instruction on how to use the new age limit field. 
