### PR TITLE
Get GitHub tickets and Zendesk users on an individual basis based off of the open Zendesk tickets

### DIFF
--- a/enhancement_tracking/models.py
+++ b/enhancement_tracking/models.py
@@ -18,6 +18,8 @@ class GZUserProfile(models.Model):
     zen_fieldid = models.IntegerField(null=True,
                                       verbose_name='Zendesk Ticket \
                                       Association Field ID')
+    utc_offset = models.IntegerField(null=True, 
+                                     verbose_name='Time Zone (UTC Offset)')
 
     def __str__(self):
         return "%s's profile" % self.user

--- a/enhancement_tracking/models.py
+++ b/enhancement_tracking/models.py
@@ -14,13 +14,10 @@ class GZUserProfile(models.Model):
     zen_token = EncryptedCharField(max_length=75,
                                    verbose_name='Zendesk API Token')
     zen_url = models.CharField(max_length=100,
-                               verbose_name='Zendesk URL')
+                               verbose_name='Zendesk URL Subdomain')
     zen_fieldid = models.IntegerField(null=True,
                                       verbose_name='Zendesk Ticket \
                                       Association Field ID')
-    age_limit = models.IntegerField(null=True,
-                                    verbose_name='Age Limit (in days) for \
-                                    the Tickets')
 
     def __str__(self):
         return "%s's profile" % self.user

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -40,19 +40,6 @@
 					<td>{{ enhancement.z_requester }}</td>
 					<td class="open">{{ enhancement.z_date }}</td>
 					<td class="closed">{{ enhancement.g_date }}</td>
-					<td>
-					{% if enhancement.g_labels %}
-						{% for label in enhancement.g_labels %}
-							{% if not forloop.last %}
-								{{ label }},
-							{% else %}
-								{{ label }}
-							{% endif %}
-						{% endfor %}
-					{% else %}
-						None
-					{% endif %}
-					</td>
 				</tr>
 			{% endfor %}
 			</tbody>
@@ -92,19 +79,6 @@
 					<td>{{ enhancement.z_requester }}</td>
 					<td class="open">{{ enhancement.z_date }}</td>
 					<td class="open">{{ enhancement.g_date }}</td>
-					<td>
-					{% if enhancement.g_labels %}
-						{% for label in enhancement.g_labels %}
-							{% if not forloop.last %}
-								{{ label }},
-							{% else %}
-								{{ label }}
-							{% endif %}
-						{% endfor %}
-					{% else %}
-						None
-					{% endif %}
-					</td>
 				</tr>
 			{% endfor %}
 			</tbody>

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -33,14 +33,16 @@
 				<tr>
 					<td>
 						<a class="open" href="{{ zen_url }}/tickets/
-							{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a> 
-						--&gt; <a class="closed" href="{{ enhancement.g_url }}"
-							>G{{ enhancement.g_id }}</a>
+							{{ enhancement.zen_id }}"
+							>Z{{ enhancement.zen_id }}</a> 
+						--&gt; <a class="closed" 
+							href="{{ enhancement.git_url }}"
+							>G{{ enhancement.git_id }}</a>
 					</td>
-					<td>{{ enhancement.z_subject }}</td>
-					<td>{{ enhancement.z_requester }}</td>
-					<td class="open">{{ enhancement.z_date }}</td>
-					<td class="closed">{{ enhancement.g_date }}</td>
+					<td>{{ enhancement.zen_subject }}</td>
+					<td>{{ enhancement.zen_requester }}</td>
+					<td class="open">{{ enhancement.zen_date }}</td>
+					<td class="closed">{{ enhancement.git_date }}</td>
 				</tr>
 			{% endfor %}
 			</tbody>
@@ -73,14 +75,15 @@
 				<tr>
 					<td>
 						<a class="open" href="{{ zen_url }}/tickets/
-							{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a> 
-						--&gt; <a class="open" href="{{ enhancement.g_url }}"
-							>G{{enhancement.g_id }}</a>
+							{{ enhancement.zen_id }}"
+							>Z{{ enhancement.zen_id }}</a> 
+						--&gt; <a class="open" href="{{ enhancement.git_url }}"
+							>G{{enhancement.git_id }}</a>
 					</td>
-					<td>{{ enhancement.z_subject }}</td>
-					<td>{{ enhancement.z_requester }}</td>
-					<td class="open">{{ enhancement.z_date }}</td>
-					<td class="open">{{ enhancement.g_date }}</td>
+					<td>{{ enhancement.zen_subject }}</td>
+					<td>{{ enhancement.zen_requester }}</td>
+					<td class="open">{{ enhancement.zen_date }}</td>
+					<td class="open">{{ enhancement.git_date }}</td>
 				</tr>
 			{% endfor %}
 			</tbody>
@@ -115,11 +118,11 @@
 			<tr>
 				<td>
 					<a class="open" href="{{ zen_url }}/tickets/
-						{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a>
+						{{ enhancement.zen_id }}">Z{{ enhancement.zen_id }}</a>
 				</td>
-				<td>{{ enhancement.z_subject }}</td>
-				<td>{{ enhancement.z_requester }}</td>
-				<td>{{ enhancement.z_date }}</td>
+				<td>{{ enhancement.zen_subject }}</td>
+				<td>{{ enhancement.zen_requester }}</td>
+				<td>{{ enhancement.zen_date }}</td>
 				<td>{{ enhancement.broken_assoc }}</td>
 			</tr>
 		{% endfor %}
@@ -150,11 +153,11 @@
 			<tr>
 				<td>
 					<a class="open" href="{{ zen_url }}/tickets/
-					{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a>
+					{{ enhancement.zen_id }}">Z{{ enhancement.zen_id }}</a>
 				</td>
-				<td>{{ enhancement.z_subject }}</td>
-				<td>{{ enhancement.z_requester }}</td>
-				<td>{{ enhancement.z_date }}</td>
+				<td>{{ enhancement.zen_subject }}</td>
+				<td>{{ enhancement.zen_requester }}</td>
+				<td>{{ enhancement.zen_date }}</td>
 			</tr>
 		{% endfor %}
 		</tbody>

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -24,7 +24,6 @@
 					<th>Requester</th>
 					<th>Last Zen Ticket Update</th>
 					<th>Last Git Ticket Update</th>
-					<th>Git Issue Labels</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -40,19 +39,6 @@
 					<td>{{ enhancement.z_requester }}</td>
 					<td class="open">{{ enhancement.z_date }}</td>
 					<td class="closed">{{ enhancement.g_date }}</td>
-					<td>
-					{% if enhancement.g_labels %}
-						{% for label in enhancement.g_labels %}
-							{% if not forloop.last %}
-								{{ label }},
-							{% else %}
-								{{ label }}
-							{% endif %}
-						{% endfor %}
-					{% else %}
-						None
-					{% endif %}
-					</td>
 				</tr>
 			{% endfor %}
 			</tbody>
@@ -76,7 +62,6 @@
 					<th>Requester</th>
 					<th>Last Zen Ticket Update</th>
 					<th>Last Git Ticket Update</th>
-					<th>Git Issue Labels</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -92,19 +77,6 @@
 					<td>{{ enhancement.z_requester }}</td>
 					<td class="open">{{ enhancement.z_date }}</td>
 					<td class="open">{{ enhancement.g_date }}</td>
-					<td>
-					{% if enhancement.g_labels %}
-						{% for label in enhancement.g_labels %}
-							{% if not forloop.last %}
-								{{ label }},
-							{% else %}
-								{{ label }}
-							{% endif %}
-						{% endfor %}
-					{% else %}
-						None
-					{% endif %}
-					</td>
 				</tr>
 			{% endfor %}
 			</tbody>

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -94,13 +94,13 @@
 
 {% if broken_enhancements %}
 <div class="row">
-<div class="span10 offset1">
+<div class="span12">
 	<h3>Requested Enhancements with Improper GitHub Associations</h3>
 	<p>The listing in the GitHub Association field should be in the format
 	"gh-###" where the "###" is the GitHub issue number of the associated
 	issue.</p>
 
-	<table class="table table-striped span10 offset1 table-center">
+	<table class="table table-striped span12 table-center">
 		<thead>
 			<tr>
 				<th>Zendesk Ticket</th>

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -127,10 +127,10 @@
 {% endif %}
 
 <div class="row">
-<div class="span8 offset2">		
+<div class="span10 offset1">		
     <h3>Requested Enhancements not Associated with GitHub</h3>
     {% if unassociated_enhancements %}
-	<table class="table table-striped span8 offset2 table-center">
+	<table class="table table-striped span10 offset1 table-center">
 		<thead>
 			<tr>
 				<th>Zendesk Ticket</th>

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -12,28 +12,30 @@
 <br/>
 
 <!-- TODO: Reformat tables to include the subject of each Zendesk ticket -->
-{% if status.tracking %}
+{% if status %}
 <div class="row">
-<div class="span6">
+<div class="span8 offest2">
     <h3>Currently Tracking</h3>
     {% if tracking %}
-		<table class="table span6 table-center">
+		<table class="table span8 offset2 table-center">
 			<thead>
 				<tr>
 					<th>Association</th>
+					<th>Zendesk Subject</th>
 					<th>Last Zen Ticket Update</th>
 					<th>Last Git Ticket Update</th>
 					<th>Git Issue Labels</th>
 				</tr>
 			</thead>
 			<tbody>
-			{% for a in tracking %}
+			{% for e in tracking %}
 				<tr>
 					<td>
 						<a class="open" href="{{ zen_url }}/tickets/
-						{{ a.z_id }}">Z{{ a.z_id }}</a> --&gt; 
-						<a class="open" href="{{ a.g_url }}">G{{ a.g_id }}</a>
+						{{ e.z_id }}">Z{{ e.z_id }}</a> --&gt; 
+						<a class="open" href="{{ e.g_url }}">G{{ e.g_id }}</a>
 					</td>
+				<td>{{ e.z_subject }}</td>
 				<td class="open">{{ a.z_date }}</td>
 				<td class="open">{{ a.g_date }}</td>
 				<td>
@@ -56,27 +58,32 @@
         <p>There are currently no Enhancements being tracked.</p>
     {% endif %}
 </div>
+</div>
+<br/>
 
-<div class="span6">
+<div class="row">
+<div class="span8 offset2">
 	<h3>Need Attention</h3>
     {% if need_attention %}
-		<table class="table span6 table-center">
+		<table class="table span8 offset2 table-center">
 			<thead>
 				<tr>
 					<th>Association</th>
+					<th>Zendesk Subject</th>
 					<th>Last Zen Ticket Update</th>
 					<th>Last Git Ticket Update</th>
 					<th>Git Issue Labels</th>
 				</tr>
 			</thead>
 			<tbody>
-			{% for a in need_attention %}
+			{% for e in need_attention %}
 				<tr>
 					<td>
 						<a class="open" href="{{ zen_url }}/tickets/
-							{{ a.z_id }}">Z{{ a.z_id }}</a> --&gt; 
-						<a class="closed" href="{{ a.g_url }}">G{{ a.g_id }}</a>
+							{{ e.z_id }}">Z{{ e.z_id }}</a> --&gt; 
+						<a class="closed" href="{{ e.g_url }}">G{{ e.g_id }}</a>
 					</td>
+					<td>{{ e.z_subject }}</td>
 					<td class="open">{{ a.z_date }}</td>
 					<td class="closed">{{ a.g_date }}</td>
 					<td>

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -11,17 +11,17 @@
 <h2>Enhancement Tracking</h2>
 <br/>
 
-<!-- TODO: Reformat tables to include the subject of each Zendesk ticket -->
 {% if status %}
 <div class="row">
-<div class="span8 offest2">
+<div class="span12">
     <h3>Currently Tracking</h3>
     {% if tracking %}
-		<table class="table span8 offset2 table-center">
+		<table class="table span12 table-center">
 			<thead>
 				<tr>
 					<th>Association</th>
 					<th>Zendesk Subject</th>
+					<th>Requester</th>
 					<th>Last Zen Ticket Update</th>
 					<th>Last Git Ticket Update</th>
 					<th>Git Issue Labels</th>
@@ -37,6 +37,7 @@
 							>G{{enhancement.g_id }}</a>
 					</td>
 					<td>{{ enhancement.z_subject }}</td>
+					<td>{{ enhancement.z_requester }}</td>
 					<td class="open">{{ enhancement.z_date }}</td>
 					<td class="open">{{ enhancment.g_date }}</td>
 					<td>
@@ -64,14 +65,15 @@
 <br/>
 
 <div class="row">
-<div class="span8 offset2">
+<div class="span12">
 	<h3>Need Attention</h3>
     {% if need_attention %}
-		<table class="table span8 offset2 table-center">
+		<table class="table span12 table-center">
 			<thead>
 				<tr>
 					<th>Association</th>
 					<th>Zendesk Subject</th>
+					<th>Requester</th>
 					<th>Last Zen Ticket Update</th>
 					<th>Last Git Ticket Update</th>
 					<th>Git Issue Labels</th>
@@ -87,6 +89,7 @@
 							>G{{ enhancement.g_id }}</a>
 					</td>
 					<td>{{ enhancement.z_subject }}</td>
+					<td>{{ enhancement.z_requester }}</td>
 					<td class="open">{{ enhancement.z_date }}</td>
 					<td class="closed">{{ enhancement.g_date }}</td>
 					<td>
@@ -126,6 +129,7 @@
 			<tr>
 				<th>Zendesk Ticket</th>
 				<th>Subject</th>
+				<th>Requester</th>
 				<th>Last Updated</th>
 				<th>Association Field Data</th>
 			</tr>
@@ -138,6 +142,7 @@
 						{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a>
 				</td>
 				<td>{{ enhancement.z_subject }}</td>
+				<td>{{ enhancement.z_requester }}</td>
 				<td>{{ enhancement.z_date }}</td>
 				<td>{{ enhancement.broken_assoc }}</td>
 			</tr>
@@ -150,52 +155,41 @@
 {% endif %}
 
 <div class="row">
-<div class="span12">		
+<div class="span8 offset2">		
     <h3>Requested Enhancements not Associated with GitHub</h3>
     {% if unassociated_enhancements %}
-	<table class="table table-striped span12 table-center">
-			<thead>
-				<tr>
-					<th>Zendesk Ticket</th>
-					<th>Last Updated</th>
-					<th>Zendesk Ticket</th>
-					<th>Last Updated</th>
-					<th>Zendesk Ticket</th>
-					<th>Last Updated</th>
-					<th>Zendesk Ticket</th>
-					<th>Last Updated</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-			{% for enhancement in unassociated_enhancements %}
+	<table class="table table-striped span8 offset2 table-center">
+		<thead>
+			<tr>
+				<th>Zendesk Ticket</th>
+				<th>Subject</th>
+				<th>Requester</th>
+				<th>Last Updated</th>
+			</tr>
+		</thead>
+		<tbody>
+		{% for enhancement in unassociated_enhancements %}
+			<tr>
 				<td>
 					<a class="open" href="{{ zen_url }}/tickets/
-						{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a>
+					{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a>
 				</td>
+				<td>{{ enhancement.z_subject }}</td>
+				<td>{{ enhancement.z_requester }}</td>
 				<td>{{ enhancement.z_date }}</td>
-				<!-- The number parameter for divisibleby will be the number of
-				tickect entries per row. -->
-				{% if not forloop.counter|divisibleby:4 %}
-					{% if forloop.last %}
-						</tr>
-					{% endif %}
-				{% else %}
-					</tr>
-					<tr>
-				{% endif %}
-			{% endfor %}
-			</tbody>
-		</table>
+			</tr>
+		{% endfor %}
+		</tbody>
+	</table>
     {% else %}
 		<p>There are currently no requested Enhancements without GitHub
 			associations.</p>
-    {% endif %}
+	{% endif %}
+</div>
+</div>
 {% else %}
 	<p>There was an Error connecting to either GitHub or Zendesk. Try adjusting
 		your account settings.</p>
 {% endif %}
-</div>
-</div>
 
 {% endblock %}

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -15,6 +15,8 @@
 <div class="row">
 <div class="span12">
 	<h3>Need Attention</h3>
+	<p>Requested enhancements whose GitHub ticket has been closed, but the
+	Zendesk ticket still remains open.</p>
     {% if need_attention %}
 		<table class="table span12 table-center">
 			<thead>
@@ -52,7 +54,9 @@
 
 <div class="row">
 <div class="span12">
-    <h3>Currently Tracking</h3>
+	<h3>Currently Tracking</h3>
+	<p>Requested enhancements whose Zendesk ticket and associated GitHub ticket
+	are still open and being worked on.</p>
     {% if tracking %}
 		<table class="table span12 table-center">
 			<thead>
@@ -128,7 +132,9 @@
 
 <div class="row">
 <div class="span10 offset1">		
-    <h3>Requested Enhancements not Associated with GitHub</h3>
+	<h3>Requested Enhancements not Associated with GitHub</h3>
+	<p>Zendesk tickets requesting an enhancement that have no associated GitHub
+	ticket.</p>
     {% if unassociated_enhancements %}
 	<table class="table table-striped span10 offset1 table-center">
 		<thead>

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -133,7 +133,7 @@
 <div class="row">
 <div class="span10 offset1">		
 	<h3>Requested Enhancements not Associated with GitHub</h3>
-	<p>Zendesk tickets requesting an enhancement that have no associated GitHub
+	<p>Zendesk tickets requesting an enhancement that has no associated GitHub
 	ticket.</p>
     {% if unassociated_enhancements %}
 	<table class="table table-striped span10 offset1 table-center">

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -11,7 +11,7 @@
 <h2>Enhancement Tracking</h2>
 <br/>
 
-{% if status %}
+{% if api_requests_successful %}
 <div class="row">
 <div class="span12">
 	<h3>Need Attention</h3>
@@ -166,8 +166,7 @@
 </div>
 </div>
 {% else %}
-	<p>There was an Error connecting to either GitHub or Zendesk. Try adjusting
-		your account settings.</p>
+	<p>{{ error_message }}</p>
 {% endif %}
 
 {% endblock %}

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -14,58 +14,6 @@
 {% if status %}
 <div class="row">
 <div class="span12">
-    <h3>Currently Tracking</h3>
-    {% if tracking %}
-		<table class="table span12 table-center">
-			<thead>
-				<tr>
-					<th>Association</th>
-					<th>Zendesk Subject</th>
-					<th>Requester</th>
-					<th>Last Zen Ticket Update</th>
-					<th>Last Git Ticket Update</th>
-					<th>Git Issue Labels</th>
-				</tr>
-			</thead>
-			<tbody>
-			{% for enhancement in tracking %}
-				<tr>
-					<td>
-						<a class="open" href="{{ zen_url }}/tickets/
-							{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a> 
-						--&gt; <a class="open" href="{{ enhancement.g_url }}"
-							>G{{enhancement.g_id }}</a>
-					</td>
-					<td>{{ enhancement.z_subject }}</td>
-					<td>{{ enhancement.z_requester }}</td>
-					<td class="open">{{ enhancement.z_date }}</td>
-					<td class="open">{{ enhancment.g_date }}</td>
-					<td>
-					{% if enhancement.g_labels %}
-						{% for label in enhancement.g_labels %}
-							{% if not forloop.last %}
-								{{ label }},
-							{% else %}
-								{{ label }}
-							{% endif %}
-						{% endfor %}
-					{% else %}
-						None
-					{% endif %}
-					</td>
-				</tr>
-			{% endfor %}
-			</tbody>
-		</table>
-    {% else %}
-        <p>There are currently no Enhancements being tracked.</p>
-    {% endif %}
-</div>
-</div>
-<br/>
-
-<div class="row">
-<div class="span12">
 	<h3>Need Attention</h3>
     {% if need_attention %}
 		<table class="table span12 table-center">
@@ -116,15 +64,67 @@
 </div>
 <br/>
 
+<div class="row">
+<div class="span12">
+    <h3>Currently Tracking</h3>
+    {% if tracking %}
+		<table class="table span12 table-center">
+			<thead>
+				<tr>
+					<th>Association</th>
+					<th>Zendesk Subject</th>
+					<th>Requester</th>
+					<th>Last Zen Ticket Update</th>
+					<th>Last Git Ticket Update</th>
+					<th>Git Issue Labels</th>
+				</tr>
+			</thead>
+			<tbody>
+			{% for enhancement in tracking %}
+				<tr>
+					<td>
+						<a class="open" href="{{ zen_url }}/tickets/
+							{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a> 
+						--&gt; <a class="open" href="{{ enhancement.g_url }}"
+							>G{{enhancement.g_id }}</a>
+					</td>
+					<td>{{ enhancement.z_subject }}</td>
+					<td>{{ enhancement.z_requester }}</td>
+					<td class="open">{{ enhancement.z_date }}</td>
+					<td class="open">{{ enhancement.g_date }}</td>
+					<td>
+					{% if enhancement.g_labels %}
+						{% for label in enhancement.g_labels %}
+							{% if not forloop.last %}
+								{{ label }},
+							{% else %}
+								{{ label }}
+							{% endif %}
+						{% endfor %}
+					{% else %}
+						None
+					{% endif %}
+					</td>
+				</tr>
+			{% endfor %}
+			</tbody>
+		</table>
+    {% else %}
+        <p>There are currently no Enhancements being tracked.</p>
+    {% endif %}
+</div>
+</div>
+<br/>
+
 {% if broken_enhancements %}
 <div class="row">
-<div class="span8 offset2">
+<div class="span10 offset1">
 	<h3>Requested Enhancements with Improper GitHub Associations</h3>
 	<p>The listing in the GitHub Association field should be in the format
 	"gh-###" where the "###" is the GitHub issue number of the associated
 	issue.</p>
 
-	<table class="table table-striped span8 offset2 table-center">
+	<table class="table table-striped span10 offset1 table-center">
 		<thead>
 			<tr>
 				<th>Zendesk Ticket</th>

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -351,7 +351,7 @@ def get_git_tickets(request, git_issue_numbers):
     return git_tickets
 
 def build_enhancement_data(zen_tickets, zen_user_reference, git_tickets,
-                           zen_fieldid, utc_offset, api_status):
+                           zen_fieldid, utc_offset):
     """Builds the enhancement tracking tables from the Zendesk and GitHub data.
     
     Parameters:

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -180,7 +180,7 @@ def home(request):
                                       # associated GitHub issue number.
     render_data = {} # Data to be rendered to the home page
 
-    zen_ticketss = [] # List of the open problem or incident tickets in Zendesk.
+    zen_tickets = [] # List of the open problem or incident tickets in Zendesk.
     zen_user_reference = {} # Dictionary reference of the user IDs and 
                             # user names associated with the Zendesk tickets in
                             # zen_tickets.
@@ -354,7 +354,7 @@ def get_git_tickets(profile, git_issue_numbers):
             if request_git_tickets.status_code != 200:
                 raise Exception('Error in accessing GitHub API - %s' % \
                                 request_git_tickets.json['message'])
-            git_tickets.extend(request_git_tickets.json)
+            git_tickets.append(request_git_tickets.json)
 
         git_ticket_status = True
     except:

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -280,9 +280,9 @@ def get_id_lists(zen_tickets, zen_fieldid):
         for field in ticket['fields']:
             if field['id'] == zen_fieldid:
                 if field['value'] is not None:
-                    association_data = field['value']
+                    association_data = field['value'].split('-')
                 break
-        if association_data and association_data.split('-')[0] == 'gh':
+        if association_data and association_data[0] == 'gh':
             git_issue_numbers.append(int(association_data[1]))
     git_issue_numbers = list(set(git_issue_numbers)) # Remove duplicates
 

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -205,7 +205,7 @@ def home(request):
     return render_to_response('home.html', render_data,
                                 context_instance=RequestContext(request))
 
-def get_zen_tickets(profile):
+def get_zen_tickets(request):
     """Gets all of the open problem and incident Zendesk tickets using the
     Zendesk API.
 
@@ -282,7 +282,7 @@ def get_id_lists(zen_tickets, zen_fieldid):
 
     return (zen_user_ids, git_issue_numbers)
 
-def get_zen_users(profile, zen_user_ids):
+def get_zen_users(request, zen_user_ids):
     """Gets the full Zendesk user records for each user ID number in the passed
     list.
 
@@ -317,7 +317,7 @@ def get_zen_users(profile, zen_user_ids):
 
     return zen_user_reference
 
-def get_git_tickets(profile, git_issue_numbers):
+def get_git_tickets(request, git_issue_numbers):
     """Gets the full GitHub ticket records for each issue number in the passed
     list.
 

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -198,8 +198,8 @@ def home(request):
     except RequestException as e:
         render_data['api_requests_successful'] = False
         render_data['error_message'] = 'There was an error connecting to the \
-                %s API - %s. Try adjusting your account settings.' % (e.args[1],
-                                                                      e.args[0])
+                %s API: %s. Try adjusting your account settings.' % (e.args[1],
+                                                                     e.args[0])
         return render_to_response('home.html', render_data,
                                     context_instance=RequestContext(request))
         

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -14,8 +14,8 @@ from datetime import datetime, timedelta
 
 # Constant URL string for accessing the GitHub API. It requires a GitHub
 # organization/user, repository, and issue number for the string's formatting.
-GIT_ISSUE_URL = 'https://api.github.com/repos/%(organization)s/\
-        %(repository)s/issues/%(issue_number)i'
+GIT_ISSUE_URL = 'https://api.github.com/repos/%(organization)s/' \
+                '%(repository)s/issues/%(issue_number)i'
 
 # Constant OAuth handler and authorization URL for access to GitHub's OAuth.
 OAUTH2_HANDLER = OAuth2(CLIENT_ID, CLIENT_SECRET, site='https://github.com/',
@@ -31,8 +31,8 @@ ZEN_SEARCH_URL = '%(subdomain)s/api/v2/search.json'
 
 # Constant search query used to access open Zendesk problem and incident tickets
 # form its API.
-ZEN_TICKET_SEARCH_QUERY = 'type:ticket ticket_type:incident \
-        ticket_type:problem status:open'
+ZEN_TICKET_SEARCH_QUERY = 'type:ticket ticket_type:incident ' \
+                        'ticket_type:problem status:open'
 
 # Constant URL string for accessing Zendesk users through the Zendesk API. It
 # requires the custom URL subdomain for the specific company whose users are

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -201,7 +201,8 @@ def home(request):
     render_data = build_enhancement_data(zen_tics, zen_user_ref, git_tics, 
                                          zen_fieldid, api_status)
 
-    # Add additional user data to be rendered to the home page
+    # Add additional data to be rendered to the home page
+    render_data['status'] = api_status
     render_data['zen_url'] = profile.zen_url
     
     return render_to_response('home.html', render_data,

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -276,14 +276,13 @@ def get_id_lists(zen_tickets, zen_fieldid):
     # Get GitHub issue numbers that are associated with the Zendesk tickets.
     git_issue_numbers = []
     for ticket in zen_tickets:
+        association_data = []
         for field in ticket['fields']:
             if field['id'] == zen_fieldid:
                 if field['value'] is not None:
                     association_data = field['value'].split('-')
-                else:
-                    association_data = ['']
                 break
-        if association_data[0] == 'gh':
+        if association_data and association_data[0] == 'gh':
             git_issue_numbers.append(int(association_data[1]))
     git_issue_numbers = list(set(git_issue_numbers)) # Remove duplicates
 

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -398,8 +398,9 @@ def build_enhancement_data(zen_tickets, zen_user_reference, git_tickets,
                         # is closed, the other needs attention.
     broken_enhancements = [] # Requested enhancements from Zendesk with a broken
                              # GitHub issue association field.
-    unassociated = [] # Requested enhancements from Zendesk tickets that have no
-                      # associatied GitHub ticket assigned to them.
+    unassociated_enhancements = [] # Requested enhancements from Zendesk 
+                                   # tickets that have no associatied GitHub
+                                   # ticket assigned to them.
     if api_status:
 
         # Iterate through the Zendesk tickets using their data to classify them

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -439,8 +439,6 @@ def build_enhancement_data(zen_tickets, zen_user_reference, git_tickets,
                     broken_enhancements.append(enhancement_data)
                     continue
                 enhancement_data['g_id'] = git_issue['number']
-                enhancement_data['g_labels'] = [label['name'] for label \
-                                                in git_issue['labels']]
                 enhancement_data['g_url'] = git_issue['html_url']
                 enhancement_data['g_status'] = git_issue['state']
                 g_date = datetime.strptime(git_issue['updated_at'], 

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -251,7 +251,7 @@ def get_zen_tickets(profile):
     except:
         zen_ticket_status = False
 
-    return (zen_tickets, zen_tickets_status)
+    return (zen_tickets, zen_ticket_status)
 
 def get_id_lists(zen_tickets, zen_fieldid):
     """Gets lists of the Zendesk user IDs and the GitHub issue numbers that are

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -413,7 +413,8 @@ def build_enhancement_data(zen_tickets, zen_user_reference, git_tickets,
                     break
             enhancement_data = {} # Enhancement data object
             enhancement_data['z_id'] = ticket['id']
-            enhancement_data['z_status'] = ticket['status']
+            enhancement_data['z_requester'] = \
+                    zen_user_reference[ticket['requester_id']]
             enhancement_data['z_subject'] = ticket['subject']
             z_date = datetime.strptime(ticket['updated_at'],
                                         "%Y-%m-%dT%H:%M:%SZ")

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -276,13 +276,13 @@ def get_id_lists(zen_tickets, zen_fieldid):
     # Get GitHub issue numbers that are associated with the Zendesk tickets.
     git_issue_numbers = []
     for ticket in zen_tickets:
-        association_data = []
+        association_data = ''
         for field in ticket['fields']:
             if field['id'] == zen_fieldid:
                 if field['value'] is not None:
-                    association_data = field['value'].split('-')
+                    association_data = field['value']
                 break
-        if association_data and association_data[0] == 'gh':
+        if association_data and association_data.split('-')[0] == 'gh':
             git_issue_numbers.append(int(association_data[1]))
     git_issue_numbers = list(set(git_issue_numbers)) # Remove duplicates
 
@@ -399,6 +399,7 @@ def build_enhancement_data(zen_tickets, zen_user_reference, git_tickets,
     for ticket in list(zen_tickets):
 
         # Add Zendesk data to enhancement data object
+        association_data = ''
         for field in ticket['fields']:
             if field['id'] == zen_fieldid:
                 association_data = field['value']
@@ -412,9 +413,8 @@ def build_enhancement_data(zen_tickets, zen_user_reference, git_tickets,
         z_date = z_date + timedelta(hours=utc_offset)
         enhancement_data['z_date'] = z_date.strftime('%m/%d/%Y @ %I:%M %p')
         
-        # Check if it has no associated  GitHub ticket
-        if association_data is None or \
-           association_data.split('-')[0] != 'gh':
+        # Check if it has no associated GitHub ticket
+        if association_data is None or association_data.split('-')[0] != 'gh':
             unassociated_enhancements.append(enhancement_data)
         
         else:

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -191,10 +191,10 @@ def home(request):
                      # tickets in zen_tickets.
     
     try:
-        zen_tickets = get_zen_tickets(request)
+        zen_tickets = get_zen_tickets(profile)
         zen_user_ids, git_issue_numbers = get_id_lists(zen_tickets, zen_fieldid)
-        zen_user_reference = get_zen_users(request, zen_user_ids)
-        git_tickets = get_git_tickets(request, git_issue_numbers)
+        zen_user_reference = get_zen_users(profile, zen_user_ids)
+        git_tickets = get_git_tickets(profile, git_issue_numbers)
     except RequestException as e:
         render_data['api_requests_successful'] = False
         render_data['error_message'] = 'There was an error connecting to the \
@@ -213,17 +213,16 @@ def home(request):
     return render_to_response('home.html', render_data,
                                 context_instance=RequestContext(request))
 
-def get_zen_tickets(request):
+def get_zen_tickets(profile):
     """Gets all of the open problem and incident Zendesk tickets using the
     Zendesk API.
 
     Parameters:
-        request - The request object that contains the current user's data 
+        profile - The profile object that contains the current user's data 
                     necessary to access the tickets on their Zendesk account.
 
     Returns a gathered list of Zendesk tickets.
     """
-    profile = request.user.get_profile()
     zen_name_tk = profile.zen_name + '/token' # Zendesk user email set up for 
                                               # API token authorization.
     zen_tickets = []
@@ -288,12 +287,12 @@ def get_id_lists(zen_tickets, zen_fieldid):
 
     return (zen_user_ids, git_issue_numbers)
 
-def get_zen_users(request, zen_user_ids):
+def get_zen_users(profile, zen_user_ids):
     """Gets the full Zendesk user records for each user ID number in the passed
     list.
 
     Parameters:
-        request - The request object that contains the current user's data
+        profile - The profile object that contains the current user's data
                     necessary to access the users on their Zendesk account.  
         zen_user_ids - A list of Zendesk user IDs whose full user records are 
                         desired.
@@ -301,7 +300,6 @@ def get_zen_users(request, zen_user_ids):
     Returns a dictionary reference table with Zendesk user ID numbers as keys
     and their cooresponding user names as values.
     """
-    profile = request.user.get_profile()
     zen_name_tk = profile.zen_name + '/token' # Zendesk user email set up for 
                                               # API token authorization.
     zen_user_reference = {} # Dictionary that allows the look up of Zendesk user
@@ -321,12 +319,12 @@ def get_zen_users(request, zen_user_ids):
     
     return zen_user_reference
 
-def get_git_tickets(request, git_issue_numbers):
+def get_git_tickets(profile, git_issue_numbers):
     """Gets the full GitHub ticket records for each issue number in the passed
     list.
 
     Parameters:
-        request - The request object that contains the current user's data
+        profile - The profile object that contains the current user's data
                     necessary to access the tickets on their GitHub account.  
         git_issue_numbers - A list of GitHub issue numbers whose full ticket
                                 records are desired.
@@ -334,7 +332,6 @@ def get_git_tickets(request, git_issue_numbers):
     Returns a list with a GitHub ticket record for each of the issue numbers
     passed to the function.
     """
-    profile = request.user.get_profile()
     git_tickets = []
     
     try:
@@ -455,24 +452,3 @@ def build_enhancement_data(zen_tickets, zen_user_reference, git_tickets,
     }
 
     return built_data
-
-def request_unsuccessful(request, responsible_api, error_details):
-    """Renders the home page with the appropriate error message if an API
-    request was unsuccessful.
-
-    Parameters:
-        request - The request object with the necessary context to render the
-                    home page.
-        responsible_api - A string of the name of the API that was
-                            unsuccessfully connected to.
-        error_details - A string of the error message or error details
-                            associated with the unsuccessful API request.
-    """
-    error_message = 'There was an error connecting to the %s API - %s. Try \
-                    adjusting your account settings.' % (responsible_api,
-                                                         error_details)
-    render_data = {'api_requests_successful': False,
-                   'error_message': error_message}
-
-    return render_to_response('home.html', render_data,
-                                context_instance=RequestContext(request))


### PR DESCRIPTION
Originally, the app gathered the necessary Zendesk and GitHub ticket information by requesting all of the tickets from both sites and then filtering them down to only the needed tickets, but now, the needed Zendesk tickets are first requested, and then only the needed Zendesk user and GitHub ticket information is individually requested based off of the information of those Zendesk tickets.

This works through a series of four get functions (`get_zendesk_tickets`, `get_id_lists`, `get_zendesk_users`, and `get_git_tickets`) that replace the old functions for making the API calls and filtering the resulting data. This new method works faster and more efficiently than the original, resulting in a faster load time for the home page after logging in to the application.

In addition to the changes made to the gathering of data, the home page template was also modified so that each table now contains more pertinent data such as the Zendesk ticket subject and the requesting Zendesk user. Also, the date and time data in the tables has been adjusted to be more readable and to account for the user's time zone (instead of having every date and time on UTC).
