### PR TITLE
Improve the styling and presentation of the profile and enhancement data

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a web application built using Django that links Zendesk and Github for
 easier developer management.
 
+
 ### Setting up the environment for Heroku deployment (on Ubuntu)
 
 1. Make a Heroku account on their [website](http://www.heroku.com/).
@@ -22,14 +23,14 @@ easier developer management.
 [here](http://www.postgresql.org/download/) so testing can be done locally.
 
 6. Clone the GitZen repo with the command
-	>`git clone git://github.com/FriedRice/GitZen.git`
+	>`git clone git://github.com/PolicyStat/GitZen.git`
 
 7. Change directories to the newly cloned GitZen directory and setup a virualenv
 using the command
 	>`virtualenv venv --distribute`
 
 8. Activate the virtualenv with the command
-	>`source venv/bin/activate`  
+	>`source venv/bin/activate`
 		
 	You must source the virtualenv environment for each terminal session where
 you wish to run your app.
@@ -43,6 +44,7 @@ psycopg2 (Postgresql support for python) in the following step.
 10. Install the required packages for GitZen and Heroku with pip by using the
 command
 	>`pip install -r requirements.txt` 
+
 
 ### Deploying the application to Heroku (on Ubuntu)
 
@@ -68,44 +70,47 @@ the commands with
 command
 	>`heroku run python manage.py syncdb`
 
+
 ### Configuration Instructions
 
 1. Go to the [GitZen website](http://gitzen.herokuapp.com) on Heroku.
 
-2. Located under the heading "New User", begin filling out the information to
-create a new user by first assigning them a username and password and filling
-the "Username", "Password", and "Confirm Password" fields with this information.
+2. Click on the "Create New User" button on the login screen.
 
-3. In order to use GitHub ticket information in GitZen, each user must provide
-information on the GitHub repository from which ticket information should be
+3. Begin filling out the information to create a new user by first assigning
+them a username and password and filling the "Username", "Password", and
+"Confirm Password" fields with this information.
+
+4. In order to use GitHub issue information in GitZen, each user must provide
+information on the GitHub repository from which issue information should be
 monitored. This access information consists of a GitHub organization name and
-repository name associated with the desired ticket information, and those
+repository name associated with the desired issue information, and those
 parameters should be filled into the "GitHub Organization" and "GitHub
-Repository" fields in the new user form respectively. If the repository is
-under a user account rather than an organization, provide the username of that
-account in the organization field instead.
+Repository" fields respectively. If the repository is under a user account
+rather than an organization, provide the username of that account in the
+organization field instead.
 
-4. In order to use Zendesk ticket information in GitZen, each user must provide
+5. In order to use Zendesk ticket information in GitZen, each user must provide
 a set of access information from a Zendesk account linked to the tickets that
 should be monitored. The first information required to access this data is a
-Zendesk user email which should be filled into the "Zendesk User Email" field in
-the new user form. The other three bits of Zendesk access information needed are
-more specific and are covered in the following steps.
+Zendesk user email which should be filled into the "Zendesk User Email" field of
+the form. The other three bits of Zendesk access information needed are more
+specific and are covered in the following steps.
 
-5. In order to allow API token access to the Zendesk account, "Token Access"
+6. In order to allow API token access to the Zendesk account, "Token Access"
 must be enabled. This option can be found by logging into Zendesk with an
 account that has administrator level credentials and looking under
 "Settings"->"Channels"->"API". After clicking "edit" and checking the "Token
 Access" box, copy the displayed API token and paste it into the "Zendesk API
-Token" field in the new user form.
+Token" field in the form.
 
-6. For the "Zendesk URL" field in the new user form, enter in the full URL that
-comes up after logging into the Zendesk account associated with the desired
-ticket information (The URL should be in the format
+7. For the "Zendesk URL Subdomain" field in the form, enter in the full
+URL that comes up after logging into the Zendesk account associated with the
+desired ticket information (The URL should be in the format
 "https://\{yourcompanyname\}.zendesk.com").
 
-7. For the "Zendesk Ticket Association Field ID" field in the new user form, the
-ID number of the field that holds the external ticket association data for each
+8. For the "Zendesk Ticket Association Field ID" field in the form, the ID
+number of the field that holds the external ticket association data for each
 Zendesk ticket must be found. In order to find this ID number, first look up the
 ID number of a Zendesk ticket from the desired account that has this ticket
 association field on it. Then open up a command terminal and enter in the
@@ -121,24 +126,20 @@ the value of the "value" key matching the value of the ticket association field
 of the Zendesk ticket that was looked up for this process. In the same
 dictionary as this "value" pair, the number value for the "id" key is the ID
 number that must be entered into the "Zendesk Ticket Association Field ID" field
-in the new user form.
+in form.
 
-8. For the "Age Limit (in days) for the Tickets" field in the new user form,
-enter a limit (in days) for the age of the tickets used in the application.
-Only tickets from Zendesk and GitHub that were last updated between the current
-time and this age limit away from the current time will be monitored in the
-application. It should be noted that the higher this age limit is set, the
-longer it will take to load the application on login, so for this reason, it is
-recommended that the age limit is not set higher than one year (365 days) to
-avoid load times that are too long for Heroku. 
+9. For the "Time Zone (UTC Offset)" field in the form, enter in the UTC offset
+of your local time zone in order to adjust the dates and times of the
+application to the proper times for your location. The number value of the
+offset should be prefaced with a "+" or "-" to indicated whether the offset is
+ahead or behind UTC time (i.e. "-4" or "+9").
 
-9. Check to see that all fields under the "New User" heading are filled out
-accurately, and then click the "Create User" button to create a user with the
-given information.
+10. Check to see that all fields in the form are filled out accurately, and then
+click the "Submit" button to create a user with the given information.
 
-10. Once the account has been created, the next page will instruct you to
-authorize GitZen on GitHub for the newly created user by following the
-hyperlink. Click this link to start the authorization process, and after it is
-completed (either automatically or by following the GitHub instructions), a
-confirmation page will come up with a link back to the login page where one can
-login to the newly created GitZen account. 
+11. Once the account has been created, the next page will instruct you to
+authorize GitZen on GitHub for the newly created user by clicking the "GitHub
+Authorization" button. Click this button to start the authorization process, and
+after it is completed (either automatically or by following the GitHub
+instructions), a confirmation page will come up with a button that links back to
+the login page where one can login to the newly created GitZen account. 

--- a/enhancement_tracking/forms.py
+++ b/enhancement_tracking/forms.py
@@ -26,11 +26,6 @@ class ProfileChangeForm(ModelForm):
     have their intial values set at the field's value for the current user's
     profile. Changing the git_token and zen_token are handled in seperate
     forms."""
-    def __init__(self, *args, **kwargs):
-        super(ProfileChangeForm, self).__init__(*args, **kwargs)
-        for key, value in self.fields.items():
-            self.fields[key].initial = getattr(self.instance, key)
-
     class Meta:
         model = GZUserProfile
         exclude = ('user', 'git_token', 'zen_token')

--- a/enhancement_tracking/forms.py
+++ b/enhancement_tracking/forms.py
@@ -1,4 +1,4 @@
-from django.forms import Form, ModelForm, CharField, IntegerField, PasswordInput
+from django.forms import ModelForm, CharField, IntegerField, PasswordInput
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import UserCreationForm
 from enhancement_tracking.models import GZUserProfile

--- a/enhancement_tracking/forms.py
+++ b/enhancement_tracking/forms.py
@@ -22,27 +22,18 @@ class UserProfileForm(ModelForm):
         }
 
 class ProfileChangeForm(ModelForm):
-    """Form for changing the data of an existing user. All of the fields are set
-    as not required. Changing the git_token and zen_token are handled in
-    seperate forms."""
+    """Form for changing the profile data of an existing user. All of the fields
+    have their intial values set at the field's value for the current user's
+    profile. Changing the git_token and zen_token are handled in seperate
+    forms."""
+    def __init__(self, *args, **kwargs):
+        super(ProfileChangeForm, self).__init__(*args, **kwargs)
+        for key, value in self.fields.items():
+            self.fields[key].initial = getattr(self.instance, key)
+
     class Meta:
         model = GZUserProfile
         exclude = ('user', 'git_token', 'zen_token')
-
-#    def __init__(self, *args, **kwargs):
-#        super(ProfileChangeForm, self).__init__(*args, **kwargs)
-#        for key, field in self.fields.items():
-#            self.fields[key].required = False
-#    
-#    # Override clean to remove the data from the fields that were left blank
-#    def clean(self):
-#        super(ProfileChangeForm, self).clean()
-#        data = self.cleaned_data
-#        for key, field in data.items():
-#            if data[key] is None or data[key] == '':
-#                del data[key]
-#
-#        return data
 
 class ZendeskTokenChangeForm(ModelForm):
     """Form for changing the Zendesk API Token of an existing user."""

--- a/enhancement_tracking/forms.py
+++ b/enhancement_tracking/forms.py
@@ -21,20 +21,34 @@ class UserProfileForm(ModelForm):
             'zen_token': PasswordInput()
         }
 
-class ProfileChangeForm(UserProfileForm):
-    """Form for changing the data of an existing user. Extends the regular user
-    profile form, but all of the fields are set as not required."""
-    def __init__(self, *args, **kwargs):
-        super(ProfileChangeForm, self).__init__(*args, **kwargs)
-        for key, field in self.fields.items():
-            self.fields[key].required = False
-    
-    # Override clean to remove the data from the fields that were left blank
-    def clean(self):
-        super(ProfileChangeForm, self).clean()
-        data = self.cleaned_data
-        for key, field in data.items():
-            if data[key] is None or data[key] == '':
-                del data[key]
+class ProfileChangeForm(ModelForm):
+    """Form for changing the data of an existing user. All of the fields are set
+    as not required. Changing the git_token and zen_token are handled in
+    seperate forms."""
+    class Meta:
+        model = GZUserProfile
+        exclude = ('user', 'git_token', 'zen_token')
 
-        return data
+#    def __init__(self, *args, **kwargs):
+#        super(ProfileChangeForm, self).__init__(*args, **kwargs)
+#        for key, field in self.fields.items():
+#            self.fields[key].required = False
+#    
+#    # Override clean to remove the data from the fields that were left blank
+#    def clean(self):
+#        super(ProfileChangeForm, self).clean()
+#        data = self.cleaned_data
+#        for key, field in data.items():
+#            if data[key] is None or data[key] == '':
+#                del data[key]
+#
+#        return data
+
+class ZendeskTokenChangeForm(ModelForm):
+    """Form for changing the Zendesk API Token of an existing user."""
+    class Meta:
+        model = GZUserProfile
+        fields = ('zen_token',)
+        widgets = {
+            'zen_token': PasswordInput()
+        }

--- a/enhancement_tracking/templates/base.html
+++ b/enhancement_tracking/templates/base.html
@@ -1,11 +1,13 @@
+<!DOCTYPE HTML>
 <html>
 <head>
 	<link rel="stylesheet" type="text/css" 
 	href="{{ STATIC_URL }}css/bootstrap.css">
+	{% block extra_head %}{% endblock %}
 	<link rel="stylesheet" type="text/css"
 	href="{{ STATIC_URL }}css/base.css">
+
 	<title>{% block title %}{% endblock %}</title>
-	{% block extra_head %}{% endblock %}
 </head>
 
 <body>

--- a/enhancement_tracking/templates/base.html
+++ b/enhancement_tracking/templates/base.html
@@ -5,7 +5,7 @@
 	href="{{ STATIC_URL }}css/bootstrap.css">
 	{% block extra_head %}{% endblock %}
 	<link rel="stylesheet" type="text/css"
-	href="{{ STATIC_URL }}css/base.css">
+	href="{{ STATIC_URL }}css/site_specific.css">
 
 	<title>{% block title %}{% endblock %}</title>
 </head>

--- a/enhancement_tracking/templates/base.html
+++ b/enhancement_tracking/templates/base.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 	<link rel="stylesheet" type="text/css" 
-	href="{{ STATIC_URL }}css/bootstrap.css">
+		href="{{ STATIC_URL }}css/bootstrap.css">
 	{% block extra_head %}{% endblock %}
 	<link rel="stylesheet" type="text/css"
-	href="{{ STATIC_URL }}css/site_specific.css">
+		href="{{ STATIC_URL }}css/site_specific.css">
 
 	<title>{% block title %}{% endblock %}</title>
 </head>

--- a/enhancement_tracking/templates/change.html
+++ b/enhancement_tracking/templates/change.html
@@ -47,7 +47,7 @@
 		applications settings of the account settings of the GitHub user who
 		authorized the access and click the "revoke" button for GitZen. If you
 		want to authorize or renew authorization of GitZen's access to Github,
-		click the link bellow.
+		click the button bellow.
 	</p>
 	<button type="button" class="btn btn-primary" 
 		onClick="window.location.href='{{ auth_url }}'">

--- a/enhancement_tracking/templates/change.html
+++ b/enhancement_tracking/templates/change.html
@@ -12,20 +12,20 @@ previous User password.</p>
 <h2>Change Password</h2>
 <form class="well" method="post">{% csrf_token %}
 	{{ password_change_form.as_p }}
-	<p><input name="password" type="submit" value="Submit Change" /></p>
+	<p><input name="password_input" type="submit" value="Submit Change" /></p>
 </form>
 <br/>
 
 <h2>Change Profile</h2>
 <form class="well" method="post">{% csrf_token %}
 	{{ profile_change_form.as_p }}
-	<p><input name="profile" type="submit" value="Submit Changes" /></p>
+	<p><input name="profile_input" type="submit" value="Submit Changes" /></p>
 </form>
 
 <h2>Change Zendesk API Token</h2>
-<form class="well">{% csrf_token %}
+<form class="well" method="post">{% csrf_token %}
 	{{ zen_token_change_form.as_p }}
-	<p><input name="zen_token" type="submit" value="Sumbit Change" /></p>
+	<p><input name="zen_token_input" type="submit" value="Sumbit Change" /></p>
 </form>
 
 <h2>Change GitHub Authorization</h2>

--- a/enhancement_tracking/templates/change.html
+++ b/enhancement_tracking/templates/change.html
@@ -15,32 +15,43 @@
 <h2>Change Password</h2>
 <form class="well" method="post">{% csrf_token %}
 	{{ password_change_form.as_p }}
-	<p><input name="password_input" type="submit" value="Submit Change" /></p>
+	<div class="actions">
+		<button name="password_input" type="submit"
+			class="btn btn-primary">Submit Change</button>
+	</div>
 </form>
 <br/>
 
 <h2>Change Profile</h2>
 <form class="well" method="post">{% csrf_token %}
 	{{ profile_change_form.as_p }}
-	<p><input name="profile_input" type="submit" value="Submit Changes" /></p>
+	<div class="actions">
+		<button name="profile_input" type="submit"
+			class="btn btn-primary">Submit Changes</button>
+	</div>
 </form>
 
 <h2>Change Zendesk API Token</h2>
 <form class="well" method="post">{% csrf_token %}
 	{{ zen_token_change_form.as_p }}
-	<p><input name="zen_token_input" type="submit" value="Sumbit Change" /></p>
+	<div class="actions">
+		<button name="zen_token_input" type="submit"
+			class="btn btn-primary">Submit Change</button>
+	</div>
 </form>
 
 <h2>Change GitHub Authorization</h2>
 <form class="well">
-	<p class="center" style="width:70%">
+	<p class="center" style="width:70%;">
 		If you want to revoke GitZen's access to GitHub, go under the
 		applications settings of the account settings of the GitHub user who
 		authorized the access and click the "revoke" button for GitZen. If you
 		want to authorize or renew authorization of GitZen's access to Github,
 		click the link bellow.
 	</p>
-	<a href="{{ auth_url }}">GitHub Authorization</a>
+	<button type="button" class="btn btn-primary" 
+		onClick="window.location.href='{{ auth_url }}'">
+		GitHub Authorization</button>
 </form>
 
 {% endblock %}

--- a/enhancement_tracking/templates/change.html
+++ b/enhancement_tracking/templates/change.html
@@ -5,9 +5,12 @@
 {% block body %}
 
 <h1>Change Account Data</h1>
-<p>All fields are optional. Changing the User password requires entering of the
-previous User password.</p>
-<br/>
+<p>
+	All fields are optional. Changing the User password requires entering of the
+	previous User password.
+	<br/>
+	<a href="{% url home %}">Return to Home</a>
+</p>
 
 <h2>Change Password</h2>
 <form class="well" method="post">{% csrf_token %}

--- a/enhancement_tracking/templates/change.html
+++ b/enhancement_tracking/templates/change.html
@@ -5,23 +5,27 @@
 {% block body %}
 
 <h1>Change Account Data</h1>
-<p style="width:30%;margin-left:auto;margin-right:auto">All fields are 
-optional. Changing the User password requires entering of the previous 
-User password.</p>
+<p>All fields are optional. Changing the User password requires entering of the
+previous User password.</p>
 <br/>
 
 <h2>Change Password</h2>
 <form class="well" method="post">{% csrf_token %}
-	{{ pwform.as_p }}
+	{{ password_change_form.as_p }}
 	<p><input name="password" type="submit" value="Submit Change" /></p>
 </form>
-
 <br/>
 
 <h2>Change Profile</h2>
 <form class="well" method="post">{% csrf_token %}
-	{{ prform.as_p }}
+	{{ profile_change_form.as_p }}
 	<p><input name="profile" type="submit" value="Submit Changes" /></p>
+</form>
+
+<h2>Change Zendesk API Token</h2>
+<form class="well">{% csrf_token %}
+	{{ zen_token_change_form.as_p }}
+	<p><input name="zen_token" type="submit" value="Sumbit Change" /></p>
 </form>
 
 <h2>Change GitHub Authorization</h2>

--- a/enhancement_tracking/templates/confirm.html
+++ b/enhancement_tracking/templates/confirm.html
@@ -18,17 +18,17 @@
 			link if you are logged into GitHub, and you should be redirected
 			straight to the confirmation page.
 		</p>
-		<a href="{{ auth_url }}">GitHub Authorization</a>
+		<button type="button" class="btn btn-primary" 
+			onClick="window.location.href='{{ auth_url }}'">
+			GitHub Authorization</button>
 	{% else %}
 		{% if con_num == '2' %}
 			<p>
 				Your account has been updated with the entered information.
 			</p>
-			<a href="{% url home %}">Return to Homepage</a>
-		{% else %}
-			<p>
-				You should not be viewing this page.
-			</p>
+			<button type="button" class="btn" 
+				onClick="window.location.href='{% url home %}'">
+				Return to Home</button>
 		{% endif %}
 	{% endif %}
 {% endblock %}

--- a/enhancement_tracking/templates/create_user.html
+++ b/enhancement_tracking/templates/create_user.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}Create User{% endblock %}
+
+{% block body %}
+
+<h1>User Creation</h1>
+<p style="width:50%">Fill out all of the fields below and click 
+"Submit" to create a new user.</p>
+<br/>
+
+<form class="well" method="post">{% csrf_token %}
+	{{ user_from.as_p }}
+	{{ profile_form.as_p }}
+	<p><input name="new" type="submit" value="Submit" /></p>
+</form>
+
+{% endblock %}

--- a/enhancement_tracking/templates/create_user.html
+++ b/enhancement_tracking/templates/create_user.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Create User{% endblock %}
+{% block title %}User Creation{% endblock %}
 
 {% block body %}
 

--- a/enhancement_tracking/templates/git_confirm.html
+++ b/enhancement_tracking/templates/git_confirm.html
@@ -6,22 +6,26 @@
 	<h2>GitHub Access Confirmation</h2>
 
 	{% if access %}
-		<p class="center" style="width:50%">
+		<p class="center" style="width:50%;">
 			You have successfully authorized GitZen to access your GitHub
 			repository data.
 		</p>
 	{% else %}
-		<p class="center" style="width:50%">
+		<p class="center" style="width:50%;">
 			GitZen did not receive authorization to access your GitHub
-			repository, so the application will not be able to display GitHub
-			information for this user. If you want to give this user's account
-			access to GitHub, you can authorize their account under "Change
-			Account Settings" after logging into the application.
+			repository, so the application will not be able to function for this
+			user. If you want to give this user's account access to GitHub, you
+			can authorize their account under "Change Account Settings" after
+			logging into the application.
 		</p>
 	{% endif %}
-	{% if new_auth %}
-		<a href="{% url login %}">Return to Login</a>
+	{% if new_user %}
+		<button type="button" class="btn" 
+			onClick="window.location.href='{% url login %}'">
+			Return to Login</button>
 	{% else %}
-		<a href="{% url home %}">Return to Home</a>
+		<button type="button" class="btn" 
+			onClick="window.location.href='{% url home %}'">
+			Return to Home</button>
 	{% endif %}
 {% endblock %}

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -38,14 +38,14 @@
 <h2>Enhancement Tracking</h2>
 {% if api_requests_successful %}
 <ul class="nav nav-tabs">
-	<li class="active"><a href="#attention" data-toggle="tab"
+	<li class="active"><a href="#attention_tab" data-toggle="tab"
 		>Need Attention ({{ need_attention|length }})</a></li>
-	<li><a href="#tracking" data-toggle="tab"
+	<li><a href="#tracking_tab" data-toggle="tab"
 		>Currently Tracking ({{ tracking|length }})</a></li>
-	<li><a href="#unassociated" data-toggle="tab"
+	<li><a href="#unassociated_tab" data-toggle="tab"
 		>Unassociated Enhancements ({{ unassociated_enhancements|length }})</a>
 	</li>
-	<li><a href="#broken" data-toggle="tab"
+	<li><a href="#broken_tab" data-toggle="tab"
 		{%if broken_enhancements %}
 			class="attention"
 		{% endif %}
@@ -54,7 +54,7 @@
 
 <div class="tab-content">
 
-<div class="tab-pane active" id="attention">
+<div class="tab-pane active" id="attention_tab">
 <div class="row">
 <div class="span12">
 	<p>Requested enhancements whose GitHub ticket has been closed, but the
@@ -86,11 +86,17 @@
 					<td>{{ enhancement.z_subject }}</td>
 					<td>{{ enhancement.z_requester }}</td>
 					<td class="open td-centered">
+						<span style="display:none;">
+							{{ enhancement.z_sortable_datetime }}
+						</span>
 						{{ enhancement.z_date }}
 						<br/>
 						{{ enhancement.z_time }}
 					</td>
 					<td class="closed td-centered">
+						<span style="display:none;">
+							{{ enhancement.g_sortable_datetime }}
+						</span>
 						{{ enhancement.g_date }}
 						<br/>
 						{{ enhancement.g_time }}
@@ -106,7 +112,7 @@
 </div>
 </div>
 
-<div class="tab-pane" id="tracking">
+<div class="tab-pane" id="tracking_tab">
 <div class="row">
 <div class="span12">
 	<p>Requested enhancements whose Zendesk ticket and associated GitHub ticket
@@ -138,11 +144,17 @@
 					<td>{{ enhancement.z_subject }}</td>
 					<td>{{ enhancement.z_requester }}</td>
 					<td class="open td-centered">
+						<span style="display:none;">
+							{{ enhancement.z_sortable_datetime }}
+						</span>
 						{{ enhancement.z_date }}
 						<br/>
 						{{ enhancement.z_time }}
 					</td>
 					<td class="open td-centered">
+						<span style="display:none;">
+							{{ enhancement.g_sortable_datetime }}
+						</span>
 						{{ enhancement.g_date }}
 						<br/>
 						{{ enhancement.g_time }}
@@ -158,7 +170,54 @@
 </div>
 </div>
 
-<div class="tab-pane" id="broken">
+<div class="tab-pane" id="unassociated_tab">
+<div class="row">
+<div class="span12">		
+	<p>Zendesk tickets requesting an enhancement that has no associated GitHub
+	ticket.</p>
+	<br/>
+
+    {% if unassociated_enhancements %}
+	<table class="table table-striped table-bordered span12
+		dataTable table-center">
+		<thead>
+			<tr>
+				<th class="th-centered">Zendesk Ticket</th>
+				<th>Zendesk Subject</th>
+				<th>Requester</th>
+				<th class="th-centered">Last Updated</th>
+			</tr>
+		</thead>
+		<tbody>
+		{% for enhancement in unassociated_enhancements %}
+			<tr>
+				<td class="td-centered">
+					<a class="open" href="{{ zen_url }}/tickets/
+					{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a>
+				</td>
+				<td>{{ enhancement.z_subject }}</td>
+				<td>{{ enhancement.z_requester }}</td>
+				<td class="td-centered">
+					<span style="display:none;">
+						{{ enhancement.z_sortable_datetime }}
+					</span>
+					{{ enhancement.z_date }}
+					<br/>
+					{{ enhancement.z_time }}
+				</td>
+			</tr>
+		{% endfor %}
+		</tbody>
+	</table>
+    {% else %}
+		<p>There are currently no requested enhancements without GitHub
+			associations.</p>
+	{% endif %}
+</div>
+</div>
+</div>
+
+<div class="tab-pane" id="broken_tab">
 <div class="row">
 <div class="span12">
 {% if broken_enhancements %}
@@ -188,6 +247,9 @@
 				<td>{{ enhancement.z_subject }}</td>
 				<td>{{ enhancement.z_requester }}</td>
 				<td class="td-centered">
+					<span style="display:none;">
+						{{ enhancement.z_sortable_datetime }}
+					</span>
 					{{ enhancement.z_date }}
 					<br/>
 					{{ enhancement.z_time }}
@@ -200,50 +262,6 @@
 {% else %}
 	<p>There are currently no broken enhancements.</p>
 {% endif %}
-</div>
-</div>
-</div>
-
-<div class="tab-pane" id="unassociated">
-<div class="row">
-<div class="span12">		
-	<p>Zendesk tickets requesting an enhancement that has no associated GitHub
-	ticket.</p>
-	<br/>
-
-    {% if unassociated_enhancements %}
-	<table class="table table-striped table-bordered span12
-		dataTable table-center">
-		<thead>
-			<tr>
-				<th class="th-centered">Zendesk Ticket</th>
-				<th>Zendesk Subject</th>
-				<th>Requester</th>
-				<th class="th-centered">Last Updated</th>
-			</tr>
-		</thead>
-		<tbody>
-		{% for enhancement in unassociated_enhancements %}
-			<tr>
-				<td class="td-centered">
-					<a class="open" href="{{ zen_url }}/tickets/
-					{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a>
-				</td>
-				<td>{{ enhancement.z_subject }}</td>
-				<td>{{ enhancement.z_requester }}</td>
-				<td class="td-centered">
-					{{ enhancement.z_date }}
-					<br/>
-					{{ enhancement.z_time }}
-				</td>
-			</tr>
-		{% endfor %}
-		</tbody>
-	</table>
-    {% else %}
-		<p>There are currently no requested enhancements without GitHub
-			associations.</p>
-	{% endif %}
 </div>
 </div>
 </div>

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -11,6 +11,8 @@
 	src="{{ STATIC_URL }}js/jquery.dataTables.js"></script>
 <script type="text/javascript" language="javascript"
 	src="{{ STATIC_URL }}js/paging.js"></script>
+<script type="text/javascript" language="javascript"
+	src="{{ STATIC_URL }}js/bootstrap-tab.js"></script>
 <script type="text/javascript">
 	$.extend( $.fn.dataTableExt.oStdClasses, {
 		"sWrapper": "dataTables_wrapper form-inline"
@@ -19,7 +21,9 @@
 	$(document).ready(function() {
 		$('.dataTable').dataTable( {
 			"sDom": "<'row'<'span6'l><'span6'f>r>t<'row'<'span6'i><'span6'p>>",
-			"sPaginationType": "bootstrap"
+			"sPaginationType": "bootstrap",
+			"iDisplayLength": 5,
+			"aLengthMenu": [[5, 10, 25, -1], [5, 10, 25, "All"]]
 		} );
 	} );
 </script>
@@ -32,26 +36,40 @@
 <br/>
 
 <h2>Enhancement Tracking</h2>
-<br/>
-
 {% if api_requests_successful %}
+<ul class="nav nav-tabs">
+	<li class="active"><a href="#attention" data-toggle="tab"
+		>Need Attention</a></li>
+	<li><a href="#tracking" data-toggle="tab"
+		>Currently Tracking</a></li>
+	<li><a href="#unassociated" data-toggle="tab"
+		>Unassociated Enhancements</a></li>
+	<li><a href="#broken" data-toggle="tab"
+		{%if broken_enhancements %}
+			class="closed"
+		{% endif %}
+	>Broken Enhancements</a></li>
+</ul>
+
+<div class="tab-content">
+
+<div class="tab-pane active" id="attention">
 <div class="row">
 <div class="span12">
-	<h3>Need Attention</h3>
 	<p>Requested enhancements whose GitHub ticket has been closed, but the
 	Zendesk ticket still remains open.</p>
 	<br/>
 
     {% if need_attention %}
-	<table class="table table-striped table-bordered span12 
+	<table class="table table-striped table-bordered span12
 		dataTable table-center">
 			<thead>
 				<tr>
 					<th class="th-centered">Association</th>
 					<th>Zendesk Subject</th>
 					<th>Requester</th>
-					<th class="th-centered">Last Zendesk<br/>Ticket Update</th>
-					<th class="th-centered">Last GitHub<br/>Ticket Update</th>
+					<th class="th-centered">Last Zendesk Ticket Update</th>
+					<th class="th-centered">Last GitHub Ticket Update</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -81,16 +99,15 @@
 			</tbody>
         </table>
     {% else %}
-        <p>There are currently no Enhancements in need of attention.</p>
+        <p>There are currently no enhancements in need of attention.</p>
     {% endif %}
 </div>
 </div>
-<br/>
-<br/>
+</div>
 
+<div class="tab-pane" id="tracking">
 <div class="row">
 <div class="span12">
-	<h3>Currently Tracking</h3>
 	<p>Requested enhancements whose Zendesk ticket and associated GitHub ticket
 	are still open and being worked on.</p>
 	<br/>
@@ -134,23 +151,22 @@
 			</tbody>
 		</table>
     {% else %}
-        <p>There are currently no Enhancements being tracked.</p>
+        <p>There are currently no enhancements being tracked.</p>
     {% endif %}
 </div>
 </div>
-<br/>
-<br/>
+</div>
 
-{% if broken_enhancements %}
+<div class="tab-pane" id="broken">
 <div class="row">
 <div class="span12">
-	<h3>Requested Enhancements with Improper GitHub Associations</h3>
+{% if broken_enhancements %}
 	<p>The listing in the GitHub Association field should be in the format
 	"gh-###" where the "###" is the GitHub issue number of the associated
 	issue.</p>
 	<br/>
 
-	<table class="table table-striped table-bordered span12 
+	<table class="table table-striped table-bordered span12
 		dataTable table-center">
 		<thead>
 			<tr>
@@ -180,21 +196,22 @@
 		{% endfor %}
 		</tbody>
 	</table>
-</div>
-</div>
-<br/>
-<br/>
+{% else %}
+	<p>There are currently no broken enhancements.</p>
 {% endif %}
+</div>
+</div>
+</div>
 
+<div class="tab-pane" id="unassociated">
 <div class="row">
 <div class="span12">		
-	<h3>Requested Enhancements not Associated with GitHub</h3>
 	<p>Zendesk tickets requesting an enhancement that has no associated GitHub
 	ticket.</p>
 	<br/>
 
     {% if unassociated_enhancements %}
-	<table class="table table-striped table-bordered span12 
+	<table class="table table-striped table-bordered span12
 		dataTable table-center">
 		<thead>
 			<tr>
@@ -228,6 +245,9 @@
 	{% endif %}
 </div>
 </div>
+</div>
+</div>
+
 {% else %}
 	<p>{{ error_message }}</p>
 {% endif %}

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -19,11 +19,64 @@
 	} );
 
 	$(document).ready(function() {
-		$('.dataTable').dataTable( {
+
+		var attention_table = $('#attention_table').dataTable( {
 			"sDom": "<'row'<'span6'l><'span6'f>r>t<'row'<'span6'i><'span6'p>>",
 			"sPaginationType": "bootstrap",
 			"iDisplayLength": 5,
-			"aLengthMenu": [[5, 10, 25, -1], [5, 10, 25, "All"]]
+			"aLengthMenu": [[5, 10, 25, -1], [5, 10, 25, "All"]],
+			"bAutoWidth": false,
+			"aoColumns": [
+				{"sWidth": "110px"},
+				{"sWidth": "400px"},
+				{"sWidth": "110px"},
+				{"sWidth": "160px"},
+				{"sWidth": "160px"}
+			]
+		} );
+
+		var tracking_table = $('#tracking_table').dataTable( {
+			"sDom": "<'row'<'span6'l><'span6'f>r>t<'row'<'span6'i><'span6'p>>",
+			"sPaginationType": "bootstrap",
+			"iDisplayLength": 5,
+			"aLengthMenu": [[5, 10, 25, -1], [5, 10, 25, "All"]],
+			"bAutoWidth": false,
+			"aoColumns": [
+				{"sWidth": "110px"},
+				{"sWidth": "400px"},
+				{"sWidth": "110px"},
+				{"sWidth": "160px"},
+				{"sWidth": "160px"}
+			]
+		} );
+
+		var unassociated_table = $('#unassociated_table').dataTable( {
+			"sDom": "<'row'<'span6'l><'span6'f>r>t<'row'<'span6'i><'span6'p>>",
+			"sPaginationType": "bootstrap",
+			"iDisplayLength": 5,
+			"aLengthMenu": [[5, 10, 25, -1], [5, 10, 25, "All"]],
+			"bAutoWidth": false,
+			"aoColumns": [
+				{"sWidth": "130px"},
+				{"sWidth": "520px"},
+				{"sWidth": "130px"},
+				{"sWidth": "160px"}
+			]
+		} );
+
+		var broken_table = $('#broken_table').dataTable( {
+			"sDom": "<'row'<'span6'l><'span6'f>r>t<'row'<'span6'i><'span6'p>>",
+			"sPaginationType": "bootstrap",
+			"iDisplayLength": 5,
+			"aLengthMenu": [[5, 10, 25, -1], [5, 10, 25, "All"]],
+			"bAutoWidth": false,
+			"aoColumns": [
+				{"sWidth": "130px"},
+				{"sWidth": "400px"},
+				{"sWidth": "110px"},
+				{"sWidth": "150px"},
+				{"sWidth": "150px"}
+			]
 		} );
 	} );
 </script>
@@ -63,14 +116,14 @@
 
     {% if need_attention %}
 	<table class="table table-striped table-bordered span12
-		dataTable table-center">
+		dataTable table-center" id="attention_table">
 			<thead>
 				<tr>
 					<th class="th-centered">Association</th>
 					<th>Zendesk Subject</th>
 					<th>Requester</th>
-					<th class="th-centered">Last Zendesk Ticket Update</th>
-					<th class="th-centered">Last GitHub Ticket Update</th>
+					<th class="th-centered">Last Zendesk<br/>Ticket Update</th>
+					<th class="th-centered">Last GitHub<br/>Ticket Update</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -121,7 +174,7 @@
 
     {% if tracking %}
 	<table class="table table-striped table-bordered span12
-		dataTable table-center">
+		dataTable table-center" id="tracking_table">
 			<thead>
 				<tr>
 					<th class="th-centered">Association</th>
@@ -179,7 +232,7 @@
 
     {% if unassociated_enhancements %}
 	<table class="table table-striped table-bordered span12
-		dataTable table-center">
+		dataTable table-center" id="unassociated_table">
 		<thead>
 			<tr>
 				<th class="th-centered">Zendesk Ticket</th>
@@ -227,14 +280,14 @@
 	<br/>
 
 	<table class="table table-striped table-bordered span12
-		dataTable table-center">
+		dataTable table-center" id="broken_table">
 		<thead>
 			<tr>
 				<th class="th-centered">Zendesk Ticket</th>
 				<th>Zendesk Subject</th>
 				<th>Requester</th>
 				<th class="th-centered">Last Updated</th>
-				<th class="th-centered">Association Field Data</th>
+				<th class="th-centered">Association<br/>Field Data</th>
 			</tr>
 		</thead>
 		<tbody>

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -47,26 +47,35 @@
 		dataTable table-center">
 			<thead>
 				<tr>
-					<th>Association</th>
+					<th class="th-centered">Association</th>
 					<th>Zendesk Subject</th>
 					<th>Requester</th>
-					<th>Last Zen Ticket Update</th>
-					<th>Last Git Ticket Update</th>
+					<th class="th-centered">Last Zendesk<br/>Ticket Update</th>
+					<th class="th-centered">Last GitHub<br/>Ticket Update</th>
 				</tr>
 			</thead>
 			<tbody>
 			{% for enhancement in need_attention %}
 				<tr>
-					<td>
+					<td class="td-centered">
 						<a class="open" href="{{ zen_url }}/tickets/
 							{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a> 
-						--&gt; <a class="closed" href="{{ enhancement.g_url }}"
+						<br/> 
+						<a class="closed" href="{{ enhancement.g_url }}"
 							>G{{ enhancement.g_id }}</a>
 					</td>
 					<td>{{ enhancement.z_subject }}</td>
 					<td>{{ enhancement.z_requester }}</td>
-					<td class="open">{{ enhancement.z_date }}</td>
-					<td class="closed">{{ enhancement.g_date }}</td>
+					<td class="open td-centered">
+						{{ enhancement.z_date }}
+						<br/>
+						{{ enhancement.z_time }}
+					</td>
+					<td class="closed td-centered">
+						{{ enhancement.g_date }}
+						<br/>
+						{{ enhancement.g_time }}
+					</td>
 				</tr>
 			{% endfor %}
 			</tbody>
@@ -91,26 +100,35 @@
 		dataTable table-center">
 			<thead>
 				<tr>
-					<th>Association</th>
+					<th class="th-centered">Association</th>
 					<th>Zendesk Subject</th>
 					<th>Requester</th>
-					<th>Last Zen Ticket Update</th>
-					<th>Last Git Ticket Update</th>
+					<th class="th-centered">Last Zendesk<br/>Ticket Update</th>
+					<th class="th-centered">Last GitHub<br/>Ticket Update</th>
 				</tr>
 			</thead>
 			<tbody>
 			{% for enhancement in tracking %}
 				<tr>
-					<td>
+					<td class="td-centered">
 						<a class="open" href="{{ zen_url }}/tickets/
 							{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a> 
-						--&gt; <a class="open" href="{{ enhancement.g_url }}"
+						<br/>
+						<a class="open" href="{{ enhancement.g_url }}"
 							>G{{enhancement.g_id }}</a>
 					</td>
 					<td>{{ enhancement.z_subject }}</td>
 					<td>{{ enhancement.z_requester }}</td>
-					<td class="open">{{ enhancement.z_date }}</td>
-					<td class="open">{{ enhancement.g_date }}</td>
+					<td class="open td-centered">
+						{{ enhancement.z_date }}
+						<br/>
+						{{ enhancement.z_time }}
+					</td>
+					<td class="open td-centered">
+						{{ enhancement.g_date }}
+						<br/>
+						{{ enhancement.g_time }}
+					</td>
 				</tr>
 			{% endfor %}
 			</tbody>
@@ -136,24 +154,28 @@
 		dataTable table-center">
 		<thead>
 			<tr>
-				<th>Zendesk Ticket</th>
-				<th>Subject</th>
+				<th class="th-centered">Zendesk Ticket</th>
+				<th>Zendesk Subject</th>
 				<th>Requester</th>
-				<th>Last Updated</th>
-				<th>Association Field Data</th>
+				<th class="th-centered">Last Updated</th>
+				<th class="th-centered">Association Field Data</th>
 			</tr>
 		</thead>
 		<tbody>
 		{% for enhancement in broken_enhancements %}
 			<tr>
-				<td>
+				<td class="td-centered">
 					<a class="open" href="{{ zen_url }}/tickets/
 						{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a>
 				</td>
 				<td>{{ enhancement.z_subject }}</td>
 				<td>{{ enhancement.z_requester }}</td>
-				<td>{{ enhancement.z_date }}</td>
-				<td>{{ enhancement.broken_assoc }}</td>
+				<td class="td-centered">
+					{{ enhancement.z_date }}
+					<br/>
+					{{ enhancement.z_time }}
+				</td>
+				<td class="td-centered">{{ enhancement.broken_assoc }}</td>
 			</tr>
 		{% endfor %}
 		</tbody>
@@ -176,28 +198,32 @@
 		dataTable table-center">
 		<thead>
 			<tr>
-				<th>Zendesk Ticket</th>
-				<th>Subject</th>
+				<th class="th-centered">Zendesk Ticket</th>
+				<th>Zendesk Subject</th>
 				<th>Requester</th>
-				<th>Last Updated</th>
+				<th class="th-centered">Last Updated</th>
 			</tr>
 		</thead>
 		<tbody>
 		{% for enhancement in unassociated_enhancements %}
 			<tr>
-				<td>
+				<td class="td-centered">
 					<a class="open" href="{{ zen_url }}/tickets/
 					{{ enhancement.z_id }}">Z{{ enhancement.z_id }}</a>
 				</td>
 				<td>{{ enhancement.z_subject }}</td>
 				<td>{{ enhancement.z_requester }}</td>
-				<td>{{ enhancement.z_date }}</td>
+				<td class="td-centered">
+					{{ enhancement.z_date }}
+					<br/>
+					{{ enhancement.z_time }}
+				</td>
 			</tr>
 		{% endfor %}
 		</tbody>
 	</table>
     {% else %}
-		<p>There are currently no requested Enhancements without GitHub
+		<p>There are currently no requested enhancements without GitHub
 			associations.</p>
 	{% endif %}
 </div>

--- a/enhancement_tracking/templates/home.html
+++ b/enhancement_tracking/templates/home.html
@@ -39,16 +39,17 @@
 {% if api_requests_successful %}
 <ul class="nav nav-tabs">
 	<li class="active"><a href="#attention" data-toggle="tab"
-		>Need Attention</a></li>
+		>Need Attention ({{ need_attention|length }})</a></li>
 	<li><a href="#tracking" data-toggle="tab"
-		>Currently Tracking</a></li>
+		>Currently Tracking ({{ tracking|length }})</a></li>
 	<li><a href="#unassociated" data-toggle="tab"
-		>Unassociated Enhancements</a></li>
+		>Unassociated Enhancements ({{ unassociated_enhancements|length }})</a>
+	</li>
 	<li><a href="#broken" data-toggle="tab"
 		{%if broken_enhancements %}
-			class="closed"
+			class="attention"
 		{% endif %}
-	>Broken Enhancements</a></li>
+		>Broken Enhancements ({{ broken_enhancements|length }})</a></li>
 </ul>
 
 <div class="tab-content">

--- a/enhancement_tracking/templates/login.html
+++ b/enhancement_tracking/templates/login.html
@@ -9,8 +9,13 @@
 
 <form class="well" method="post">{% csrf_token %}
 	{{ log_form.as_p }}
-    <p><input name="log_input" type="submit" value="Login"/></p>
+	<div class="actions">
+    	<button name="log_input" type="submit"
+			class="btn btn-primary">Login</button>
+		<button type="button" class="btn" 
+			onClick="window.location.href='{% url user_creation %}'">
+			Create New User</button>
+	</div>
 </form>
-<a href="{% url user_creation %}">Create New User</a>
 
 {% endblock %}

--- a/enhancement_tracking/templates/login.html
+++ b/enhancement_tracking/templates/login.html
@@ -11,6 +11,6 @@
 	{{ log_form.as_p }}
     <p><input name="log" type="submit" value="Login"/></p>
 </form>
-<a href="{% url create_user %}">Create New User</a>
+<a href="{% url user_creation %}">Create New User</a>
 
 {% endblock %}

--- a/enhancement_tracking/templates/login.html
+++ b/enhancement_tracking/templates/login.html
@@ -9,7 +9,7 @@
 
 <form class="well" method="post">{% csrf_token %}
 	{{ log_form.as_p }}
-    <p><input name="log" type="submit" value="Login"/></p>
+    <p><input name="log_input" type="submit" value="Login"/></p>
 </form>
 <a href="{% url user_creation %}">Create New User</a>
 

--- a/enhancement_tracking/templates/login.html
+++ b/enhancement_tracking/templates/login.html
@@ -7,19 +7,10 @@
 <h1>User Login</h1>
 <br/>
 
-<h2>Existing User</h2>
 <form class="well" method="post">{% csrf_token %}
-	{{ logform.as_p }}
+	{{ log_form.as_p }}
     <p><input name="log" type="submit" value="Login"/></p>
 </form>
-
-<br/>
-
-<h2>New User</h2>
-<form class="well" method="post">{% csrf_token %}
-	{{ uform.as_p }}
-	{{ pform.as_p }}
-	<p><input name="new" type="submit" value="Create User" /></p>
-</form>
+<a href="{% url create_user %}">Create New User</a>
 
 {% endblock %}

--- a/enhancement_tracking/templates/user_creation.html
+++ b/enhancement_tracking/templates/user_creation.html
@@ -12,7 +12,13 @@
 <form class="well" method="post">{% csrf_token %}
 	{{ user_form.as_p }}
 	{{ profile_form.as_p }}
-	<p><input name="new_user_input" type="submit" value="Submit" /></p>
+	<div class="actions">
+		<button name="new_user_input" type="submit"
+			class="btn btn-primary">Submit</button>
+		<button type="button" class="btn"
+			onClick="window.location.href='{% url login %}'">
+			Cancel</button>
+	</div>
 </form>
 
 {% endblock %}

--- a/enhancement_tracking/templates/user_creation.html
+++ b/enhancement_tracking/templates/user_creation.html
@@ -12,7 +12,7 @@
 <form class="well" method="post">{% csrf_token %}
 	{{ user_form.as_p }}
 	{{ profile_form.as_p }}
-	<p><input name="new" type="submit" value="Submit" /></p>
+	<p><input name="new_user_input" type="submit" value="Submit" /></p>
 </form>
 
 {% endblock %}

--- a/enhancement_tracking/templates/user_creation.html
+++ b/enhancement_tracking/templates/user_creation.html
@@ -5,12 +5,12 @@
 {% block body %}
 
 <h1>User Creation</h1>
-<p style="width:50%">Fill out all of the fields below and click 
+<p>Fill out all of the fields below and click 
 "Submit" to create a new user.</p>
 <br/>
 
 <form class="well" method="post">{% csrf_token %}
-	{{ user_from.as_p }}
+	{{ user_form.as_p }}
 	{{ profile_form.as_p }}
 	<p><input name="new" type="submit" value="Submit" /></p>
 </form>

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -39,7 +39,7 @@ ZEN_TICKET_SEARCH_QUERY = 'type:ticket ticket_type:incident \
 # being accessed, and the second %s is the ID number of the user being accessed.
 ZEN_USER_URL = '%s/api/v2/users/%s.json'
 
-def user_login(request):
+def user_login_form_handler(request):
     """Processes the requests from the login page and authenticates the login of
     an existing user.
 
@@ -58,7 +58,7 @@ def user_login(request):
     return render_to_response('login.html', {'log_form': log_form}, 
                               context_instance=RequestContext(request))
 
-def create_user(request):
+def user_creation_form_handler(request):
     """Process the requests from the User Creation page.
     
     If any of the fields in the submitted form are not completed properly, the
@@ -90,7 +90,7 @@ def create_user(request):
                               'profile_form': profile_form}, 
                               context_instance=RequestContext(request))
             
-def change(request):
+def change_form_handler(request):
     """Processes the requests from the Change Account Data page.
 
     All of the fields on the change forms are optional so that the user can

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -33,8 +33,7 @@ ZEN_SEARCH_URL = '%(subdomain)s/api/v2/search.json'
 
 # Constant search query used to access open Zendesk problem and incident tickets
 # form its API.
-ZEN_TICKET_SEARCH_QUERY = 'type:ticket ticket_type:incident ' \
-                        'ticket_type:problem status:open'
+ZEN_TICKET_SEARCH_QUERY = 'type:ticket tags:product_enhancement status:open'
 
 # Constant URL string for accessing Zendesk users through the Zendesk API. It
 # requires the custom URL subdomain for the specific company whose users are

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -433,7 +433,8 @@ def build_enhancement_data(zen_tickets, zen_user_reference, git_tickets,
         enhancement_data['z_subject'] = ticket['subject']
         z_date = datetime.strptime(ticket['updated_at'], "%Y-%m-%dT%H:%M:%SZ")
         z_date = z_date + timedelta(hours=utc_offset)
-        enhancement_data['z_date'] = z_date.strftime('%m/%d/%Y @ %I:%M %p')
+        enhancement_data['z_date'] = z_date.strftime('%m/%d/%Y')
+        enhancement_data['z_time'] = z_date.strftime('%I:%M %p')
         
         # Check if it has no associated GitHub ticket
         if association_data is None or association_data.split('-')[0] != 'gh':
@@ -457,7 +458,8 @@ def build_enhancement_data(zen_tickets, zen_user_reference, git_tickets,
             g_date = datetime.strptime(git_issue['updated_at'], 
                                        "%Y-%m-%dT%H:%M:%SZ")
             g_date = g_date + timedelta(hours=utc_offset)
-            enhancement_data['g_date'] = g_date.strftime('%m/%d/%Y @ %I:%M %p')
+            enhancement_data['g_date'] = g_date.strftime('%m/%d/%Y')
+            enhancement_data['g_time'] = g_date.strftime('%I:%M %p')
             
             # Check if the enhacement should be tracked (Both tickets are
             # open).

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -171,10 +171,10 @@ def git_oauth_confirm(request):
     """
     if 'profile' in request.session: # Authorizing for a new user
         profile = request.session['profile']
-        new_auth = True
+        new_user = True
     else: # Changing Authorization for an existing user
         profile = request.user.get_profile()
-        new_auth = False
+        new_user = False
 
     if 'error' in request.GET:
         profile.git_token = ''
@@ -186,11 +186,11 @@ def git_oauth_confirm(request):
         access = True
     
     profile.save()
-    if new_auth:
+    if new_user:
         del request.session['profile']
 
     return render_to_response('git_confirm.html', 
-                              {'access': access, 'new_auth': new_auth},
+                              {'access': access, 'new_user': new_user},
                               context_instance=RequestContext(request))
 
 def home(request):

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -92,18 +92,18 @@ def user_creation_form_handler(request):
                               context_instance=RequestContext(request))
             
 def change_form_handler(request):
-    """Processes the requests from the Change Account Data page.
-
-    All of the fields on the change forms are optional so that the user can
-    change only the account data that they want changed.
+    """Processes the requests from the Change Account Data page. This includes
+    requests from the password change form, profile change form, and Zendesk API
+    token chnage form.
 
     Parameters:
-        request - The request object that contains the POST data from the change
-                    form.
+        request - The request object that contains the POST data from one of the
+                    change forms.
     """
 
     if request.method == 'POST':
-        if 'password' in request.POST: # Process password change form
+        # Process password change form
+        if 'password_input' in request.POST:
             password_change_form = PasswordChangeForm(user=request.user,
                                                       data=request.POST)
             if password_change_form.is_valid():
@@ -111,8 +111,9 @@ def change_form_handler(request):
                 return HttpResponseRedirect(reverse('confirm', args=[2]))
             profile_change_form = ProfileChangeForm()
             zen_token_change_form = ZendeskTokenChangeForm()
-        
-        elif 'profile' in request.POST: # Process profile change form
+
+        # Process profile change form
+        elif 'profile_input' in request.POST:
             profile_change_form = ProfileChangeForm(data=request.POST,
                                         instance=request.user.get_profile())
             if profile_change_form.is_valid():
@@ -120,8 +121,9 @@ def change_form_handler(request):
                 return HttpResponseRedirect(reverse('confirm', args=[2]))
             password_change_form = PasswordChangeForm(user=request.user)
             zen_token_change_form = ZendeskTokenChangeForm()
-
-        elif 'zen_token' in request.POST: # Process Zen API Token change form
+        
+        # Process Zendesk API Token change form
+        elif 'zen_token_input' in request.POST: 
             zen_token_change_form = ZendeskTokenChangeForm(data=request.POST,
                                         instance=request.user.get_profile())
             if zen_token_change_form.is_valid():

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -82,7 +82,7 @@ def create_user(request):
             # can be added to it through OAuth on the next pages.
             request.session['profile'] = profile
             return HttpResponseRedirect(reverse('confirm', args=[1]))
-     else:
+    else:
         user_form = UserForm()
         profile_form = UserProfileForm()
 

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -470,7 +470,18 @@ def build_enhancement_data(zen_tickets, zen_user_reference, git_tickets,
             # ticket is closed).
             else:
                 need_attention.append(enhancement_data)
-    
+    """
+    broken_test = {
+        'z_id': '9001',
+        'z_subject': "Test. It's over 9000!",
+        'z_requester': 'Nick McLaughlin',
+        'z_date': '09/09/09',
+        'z_time': '11:11 PM',
+        'broken_assoc': 'gh-1337'
+    }
+    broken_enhancements.append(broken_test)
+    """
+
     built_data = {
         'tracking': tracking,
         'need_attention': need_attention,

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -86,7 +86,7 @@ def user_creation_form_handler(request):
         user_form = UserForm()
         profile_form = UserProfileForm()
 
-    return render_to_response('create_user.html', {'user_form': user_form,
+    return render_to_response('user_creation.html', {'user_form': user_form,
                               'profile_form': profile_form}, 
                               context_instance=RequestContext(request))
             

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -86,7 +86,7 @@ def create_user(request):
         user_form = UserForm()
         profile_form = UserProfileForm()
 
-    return render_to_response('login.html', {'user_form': user_form,
+    return render_to_response('create_user.html', {'user_form': user_form,
                               'profile_form': profile_form}, 
                               context_instance=RequestContext(request))
             

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -100,8 +100,9 @@ def change_form_handler(request):
         request - The request object that contains the POST data from one of the
                     change forms.
     """
+    profile = request.user.get_profile()
 
-    if request.method == 'POST':
+    if request.POST:
         # Process password change form
         if 'password_input' in request.POST:
             password_change_form = PasswordChangeForm(user=request.user,
@@ -115,7 +116,7 @@ def change_form_handler(request):
         # Process profile change form
         elif 'profile_input' in request.POST:
             profile_change_form = ProfileChangeForm(data=request.POST,
-                                        instance=request.user.get_profile())
+                                                    instance=profile)
             if profile_change_form.is_valid():
                 profile_change_form.save()
                 return HttpResponseRedirect(reverse('confirm', args=[2]))
@@ -125,7 +126,7 @@ def change_form_handler(request):
         # Process Zendesk API Token change form
         elif 'zen_token_input' in request.POST: 
             zen_token_change_form = ZendeskTokenChangeForm(data=request.POST,
-                                        instance=request.user.get_profile())
+                                                           instance=profile)
             if zen_token_change_form.is_valid():
                 zen_token_change_form.save()
                 return HttpResponseRedirect(reverse('confirm', args=[2]))
@@ -133,7 +134,7 @@ def change_form_handler(request):
             profile_change_form = ProfileChangeForm()
     else:
         password_change_form = PasswordChangeForm(user=request.user)
-        profile_change_form = ProfileChangeForm()
+        profile_change_form = ProfileChangeForm(instance=profile)
         zen_token_change_form = ZendeskTokenChangeForm()
     
     return render_to_response('change.html', 

--- a/enhancement_tracking/views.py
+++ b/enhancement_tracking/views.py
@@ -40,50 +40,56 @@ ZEN_TICKET_SEARCH_QUERY = 'type:ticket ticket_type:incident \
 ZEN_USER_URL = '%s/api/v2/users/%s.json'
 
 def user_login(request):
-    """Processes the requests from the login page. 
-    
-    Authenticates the login of an existing user or creates a new user by adding
-    their user data to the database. If any of the fields in the submitted form
-    are not completed properly, the login page will come up again with those
-    fields marked as needing to be properly filled.
+    """Processes the requests from the login page and authenticates the login of
+    an existing user.
 
     Parameters:
         request - The request object that contains the POST data from the login
                     forms.
-    """
-
+    """ 
     if request.method == 'POST':
-        if 'log' in request.POST:  # Process login form
-            logform = AuthenticationForm(data=request.POST)
-            if logform.is_valid():
-                login(request, logform.get_user())
-                return HttpResponseRedirect(reverse('home'))
-            uform = UserForm()
-            pform = UserProfileForm()
-
-        elif 'new' in request.POST:  # Process new user form
-            uform = UserForm(data=request.POST)
-            pform = UserProfileForm(data=request.POST)
-            if uform.is_valid() and pform.is_valid():
-                user = uform.save()
-                profile = pform.save(commit=False)
-                profile.user = user
-                profile.save()
-                
-                # Store the profile in the session so the GitHub access token
-                # can be added to it through OAuth on the next pages.
-                request.session['profile'] = profile
-                return HttpResponseRedirect(reverse('confirm', args=[1]))
-            logform = AuthenticationForm()
+        log_form = AuthenticationForm(data=request.POST)
+        if log_form.is_valid():
+            login(request, log_form.get_user())
+            return HttpResponseRedirect(reverse('home'))
     else:
-        logform = AuthenticationForm()
-        uform = UserForm()
-        pform = UserProfileForm()
+        log_form = AuthenticationForm()
 
-    return render_to_response('login.html', {'logform': logform,
-                                'uform': uform, 'pform': pform}, 
+    return render_to_response('login.html', {'log_form': log_form}, 
                               context_instance=RequestContext(request))
 
+def create_user(request):
+    """Process the requests from the User Creation page.
+    
+    If any of the fields in the submitted form are not completed properly, the
+    User Creation page will come up again with those fields marked as needing to
+    be properly filled.
+
+    Parameters:
+        request - The request object that contains the form data submitted from
+                    the User Creation page.
+    """
+    if request.method == 'POST':
+        user_form = UserForm(data=request.POST)
+        profile_form = UserProfileForm(data=request.POST)
+        if user_form.is_valid() and profile_form.is_valid():
+            user = user_form.save()
+            profile = profile_form.save(commit=False)
+            profile.user = user
+            profile.save()
+            
+            # Store the profile in the session so the GitHub access token
+            # can be added to it through OAuth on the next pages.
+            request.session['profile'] = profile
+            return HttpResponseRedirect(reverse('confirm', args=[1]))
+     else:
+        user_form = UserForm()
+        profile_form = UserProfileForm()
+
+    return render_to_response('login.html', {'user_form': user_form,
+                              'profile_form': profile_form}, 
+                              context_instance=RequestContext(request))
+            
 def change(request):
     """Processes the requests from the Change Account Data page.
 

--- a/settings.py
+++ b/settings.py
@@ -152,7 +152,7 @@ LOGGING = {
     }
 }
 
-import dj_database_url
-DATABASES = {
-    'default': dj_database_url.config(default='postgres://localhost')
-    }
+#import dj_database_url
+#DATABASES = {
+#    'default': dj_database_url.config(default='postgres://localhost')
+#    }

--- a/settings.py
+++ b/settings.py
@@ -84,13 +84,13 @@ STATICFILES_FINDERS = (
 )
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = 't+r0ueiift2w6u+essid1!^c=-pya$pbszctl4+k^vs=s)^25x'
+SECRET_KEY = 't+q0zevyft2x6p+essiv1!^v=-pya$pbklctl4+k^vs=s)^28x'
 
 # Consumer key for OAuth access of the GitHub API
 CLIENT_ID = 'ad0c98cf08bdab86a19c'
 
 # Consumer secret for OAuth access of the GitHub API
-CLIENT_SECRET = '96d7fda0551ccf2160f670922d23da843c1a75df'
+CLIENT_SECRET = '2b6b020652e02ab5880d6f34b26047efb15ac220'
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (

--- a/statics/css/base.css
+++ b/statics/css/base.css
@@ -40,3 +40,9 @@ th.th-centered
 	margin: 0 auto !important;
 	float: none !important;
 }
+
+.table tbody tr:hover td,
+.table tbody tr:hover th 
+{
+  background-color: #B5B5B5;
+}

--- a/statics/css/base.css
+++ b/statics/css/base.css
@@ -25,6 +25,16 @@ a.closed, td.closed
 	margin-right:auto;
 }
 
+td.td-centered
+{
+	text-align:center;
+}
+
+th.th-centered
+{
+	text-align:center;
+}
+
 .table-center 
 {
 	margin: 0 auto !important;

--- a/statics/css/base.css
+++ b/statics/css/base.css
@@ -46,3 +46,21 @@ th.th-centered
 {
   background-color: #B5B5B5;
 }
+
+.nav-tabs > li, .nav-pills > li 
+{
+    float:none;
+    display:inline-block;
+    *display:inline;
+     zoom:1;
+}
+
+.nav-tabs 
+{
+    text-align:center;
+}
+
+.tab-content
+{
+	overflow: visible;
+}

--- a/statics/css/bootstrap.css
+++ b/statics/css/bootstrap.css
@@ -718,7 +718,7 @@ pre code {
 }
 
 .pre-scrollable {
-  max-height: 340px;
+  max-height: 600px;
   overflow-y: scroll;
 }
 

--- a/statics/css/site_specific.css
+++ b/statics/css/site_specific.css
@@ -9,12 +9,15 @@ a:link, a:visited
 {
 	color:blue;
 }
-
 a.open, td.open 
 {
 	color:green
 }
 a.closed, td.closed 
+{
+	color:red
+}
+a.attention
 {
 	color:red
 }
@@ -44,7 +47,7 @@ th.th-centered
 .table tbody tr:hover td,
 .table tbody tr:hover th 
 {
-  background-color: #B5B5B5;
+  background-color: #C7C7C7;
 }
 
 .nav-tabs > li, .nav-pills > li 

--- a/statics/js/bootstrap-tab.js
+++ b/statics/js/bootstrap-tab.js
@@ -1,0 +1,135 @@
+/* ========================================================
+ * bootstrap-tab.js v2.0.4
+ * http://twitter.github.com/bootstrap/javascript.html#tabs
+ * ========================================================
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ======================================================== */
+
+
+!function ($) {
+
+  "use strict"; // jshint ;_;
+
+
+ /* TAB CLASS DEFINITION
+  * ==================== */
+
+  var Tab = function ( element ) {
+    this.element = $(element)
+  }
+
+  Tab.prototype = {
+
+    constructor: Tab
+
+  , show: function () {
+      var $this = this.element
+        , $ul = $this.closest('ul:not(.dropdown-menu)')
+        , selector = $this.attr('data-target')
+        , previous
+        , $target
+        , e
+
+      if (!selector) {
+        selector = $this.attr('href')
+        selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') //strip for ie7
+      }
+
+      if ( $this.parent('li').hasClass('active') ) return
+
+      previous = $ul.find('.active a').last()[0]
+
+      e = $.Event('show', {
+        relatedTarget: previous
+      })
+
+      $this.trigger(e)
+
+      if (e.isDefaultPrevented()) return
+
+      $target = $(selector)
+
+      this.activate($this.parent('li'), $ul)
+      this.activate($target, $target.parent(), function () {
+        $this.trigger({
+          type: 'shown'
+        , relatedTarget: previous
+        })
+      })
+    }
+
+  , activate: function ( element, container, callback) {
+      var $active = container.find('> .active')
+        , transition = callback
+            && $.support.transition
+            && $active.hasClass('fade')
+
+      function next() {
+        $active
+          .removeClass('active')
+          .find('> .dropdown-menu > .active')
+          .removeClass('active')
+
+        element.addClass('active')
+
+        if (transition) {
+          element[0].offsetWidth // reflow for transition
+          element.addClass('in')
+        } else {
+          element.removeClass('fade')
+        }
+
+        if ( element.parent('.dropdown-menu') ) {
+          element.closest('li.dropdown').addClass('active')
+        }
+
+        callback && callback()
+      }
+
+      transition ?
+        $active.one($.support.transition.end, next) :
+        next()
+
+      $active.removeClass('in')
+    }
+  }
+
+
+ /* TAB PLUGIN DEFINITION
+  * ===================== */
+
+  $.fn.tab = function ( option ) {
+    return this.each(function () {
+      var $this = $(this)
+        , data = $this.data('tab')
+      if (!data) $this.data('tab', (data = new Tab(this)))
+      if (typeof option == 'string') data[option]()
+    })
+  }
+
+  $.fn.tab.Constructor = Tab
+
+
+ /* TAB DATA-API
+  * ============ */
+
+  $(function () {
+    $('body').on('click.tab.data-api', '[data-toggle="tab"], [data-toggle="pill"]', function (e) {
+      e.preventDefault()
+      $(this).tab('show')
+    })
+  })
+
+}(window.jQuery);

--- a/urls.py
+++ b/urls.py
@@ -5,10 +5,10 @@ from django.conf.urls.defaults import patterns, include, url
 # admin.autodiscover()
 
 urlpatterns = patterns('enhancement_tracking.views',
-    url(r'^$', 'user_login', name='login'),
-    url(r'^create/$', 'create_user', name='create_user'),
+    url(r'^$', 'user_login_form_handler', name='login'),
+    url(r'^create/$', 'user_creation_form_handler', name='user_creation'),
     url(r'^home/$', 'home', name='home'),
-    url(r'^change/$', 'change', name='change'),
+    url(r'^change/$', 'change_form_handler', name='change'),
     url(r'^git_confirm/$', 'git_oauth_confirm', name='git_confirm'),
     url(r'^confirm/(?P<con_num>\d+)/$', 'confirm', name='confirm'),
 ) 

--- a/urls.py
+++ b/urls.py
@@ -6,7 +6,7 @@ from django.conf.urls.defaults import patterns, include, url
 
 urlpatterns = patterns('enhancement_tracking.views',
     url(r'^$', 'user_login', name='login'),
-    url(r'^create/$', 'create_user', name='create_user')
+    url(r'^create/$', 'create_user', name='create_user'),
     url(r'^home/$', 'home', name='home'),
     url(r'^change/$', 'change', name='change'),
     url(r'^git_confirm/$', 'git_oauth_confirm', name='git_confirm'),

--- a/urls.py
+++ b/urls.py
@@ -6,6 +6,7 @@ from django.conf.urls.defaults import patterns, include, url
 
 urlpatterns = patterns('enhancement_tracking.views',
     url(r'^$', 'user_login', name='login'),
+    url(r'^create/$', 'create_user', name='create_user')
     url(r'^home/$', 'home', name='home'),
     url(r'^change/$', 'change', name='change'),
     url(r'^git_confirm/$', 'git_oauth_confirm', name='git_confirm'),


### PR DESCRIPTION
These changes improved a multitude of issues dealing with the handling and presentation of profile data and the enhancement data generated from that profile data.

This includes:
- Changed and secured the client secret ID used in GitHub's OAuth and the secret key used to encrypt the Zendesk and GitHub API access tokens in the database. Since I plan to only submit code changes to the private PolicyStat GitZen repo instead of my public fork now, these new keys will not be publicly accessible like the old keys.
- Moved the user creation form off the login screen and onto its own page.
- Changed the change profile data form on the change account data page so that the user can see their present profile information while changing it. Also, moved the option to change the Zendesk API token to a separate form to keep it secured from being viewed by the user.
- Improved the styling of the text input boxes and the form actions buttons on all of the forms in the application.
- Modified the home page to use a tabular set up that places each data table under an individual tab. This makes browsing through the enhancement data much easier and more efficient.
- Fixed several issues with the dataTables implementation in the enhancement tables including working date sorting, fixed column widths, and better increments for the length menu.
- Updated README with instructions that reflect the changes made to the create user process.
- Made a number of other small enhancements as extensions to those already listed.
