### PR TITLE
Zendesk ticket links are broken

### DIFF
--- a/gitzen/enhancement_tracking/cache_actions.py
+++ b/gitzen/enhancement_tracking/cache_actions.py
@@ -762,12 +762,19 @@ def _update_enhancement_zen_data(enhancement, zen_ticket, zen_user_reference):
         enhancement - A dictionary of enhancement data.
         zen_ticket - A dictionary of ticket data for a Zendesk ticket that will
                         be used to update the passed enhancement dictionary.
+        zen_user_reference - A dictionary reference for Zendesk usernames
+                                with the keys being the users' IDs.
 
     Returns the enhancement dictionary with it's base Zendesk fields updated with
     the data from the passed Zendesk ticket.
     """
     enhancement['zen_subject'] = zen_ticket['subject']
     enhancement['zen_requester'] = zen_user_reference[zen_ticket['requester_id']]
+
+    zen_subdomain = zen_ticket['url'].split('//')[1].split('.')[0]
+    enhancement['zen_url'] = 'http://%s.zendesk.com/tickets/%s' % \
+            (zen_subdomain, zen_ticket['id'])
+
     zen_datetime = datetime.strptime(
         zen_ticket['updated_at'], "%Y-%m-%dT%H:%M:%SZ"
     )
@@ -791,10 +798,12 @@ def _update_zen_no_association(cache_data, zen_ticket):
     the cache.
     """
     zen_user_reference = cache_data['zen_user_reference']
+
     for enhancement in cache_data['need_attention']:
         if enhancement['zen_id'] == zen_ticket['id']:
             enhancement = _update_enhancement_zen_data(enhancement, zen_ticket,
                                                        zen_user_reference)
+
             enhancement = _delete_enhancement_git_data(enhancement)
             cache_data['unassociated_enhancements'].append(enhancement)
             cache_data['need_attention'] = _rm_from_diclist(
@@ -806,6 +815,7 @@ def _update_zen_no_association(cache_data, zen_ticket):
         if enhancement['zen_id'] == zen_ticket['id']:
             enhancement = _update_enhancement_zen_data(enhancement, zen_ticket,
                                                        zen_user_reference)
+
             enhancement = _delete_enhancement_git_data(enhancement)
             cache_data['unassociated_enhancements'].append(enhancement)
             cache_data['tracking'] = _rm_from_diclist(
@@ -823,6 +833,7 @@ def _update_zen_no_association(cache_data, zen_ticket):
         if enhancement['zen_id'] == zen_ticket['id']:
             enhancement = _update_enhancement_zen_data(enhancement, zen_ticket,
                                                        zen_user_reference)
+
             del enhancement['non_git_association']
             cache_data['unassociated_enhancements'].append(enhancement)
             cache_data['not_git_enhancements'] =  _rm_from_diclist(

--- a/gitzen/enhancement_tracking/cache_actions.py
+++ b/gitzen/enhancement_tracking/cache_actions.py
@@ -422,7 +422,7 @@ def update_cache_index(api_access_data):
                             updated_git_tickets, 'number', ticket['number']
                         )
                 else:
-                    for i in range(len(cache_data['git_tickets'])):
+                    for i in xrange(len(cache_data['git_tickets'])):
                         if cache_data['git_tickets'][i]['number'] == \
                         ticket['number']:
                             cache_data['git_ticket'][i] = ticket
@@ -593,7 +593,7 @@ def _rm_from_diclist(diclist, key_to_check, value_to_check):
     Returns the diclist passed to the function with an entry removed if its
     value of the key_to_check matched the value_to_check.
     """
-    for i in range(len(diclist)):
+    for i in xrange(len(diclist)):
         if diclist[i][key_to_check] == value_to_check:
             diclist.pop(i)
             break
@@ -772,7 +772,7 @@ def _update_enhancement_zen_data(enhancement, zen_ticket, zen_user_reference):
     enhancement['zen_requester'] = zen_user_reference[zen_ticket['requester_id']]
 
     zen_subdomain = zen_ticket['url'].split('//')[1].split('.')[0]
-    enhancement['zen_url'] = 'http://%s.zendesk.com/tickets/%s' % \
+    enhancement['zen_url'] = 'https://%s.zendesk.com/tickets/%s' % \
             (zen_subdomain, zen_ticket['id'])
 
     zen_datetime = datetime.strptime(

--- a/gitzen/enhancement_tracking/templates/confirm_group_creation.html
+++ b/gitzen/enhancement_tracking/templates/confirm_group_creation.html
@@ -6,7 +6,7 @@
 <script>
 	$(document).ready(function() {
 		$('#git_oauth_button').click(function() {
-			window.location.href='{% url confirm_git_oauth %}';
+			window.location.href='{{ auth_url }}';
 		});
 	});
 </script>

--- a/gitzen/enhancement_tracking/templates/home.html
+++ b/gitzen/enhancement_tracking/templates/home.html
@@ -172,8 +172,7 @@
 					<td class="td-centered">
 					{% if is_zendesk_user %}
 						<a class="open" target="_blank" 
-							href="{{ zen_url }}/tickets/
-							{{ enhancement.zen_id }}"
+							href="{{ enhancement.zen_url }}"
 							>Z{{ enhancement.zen_id }}</a>
 						<br/> 
 						<a class="closed" target="_blank" 
@@ -185,8 +184,7 @@
 							>G{{ enhancement.git_id }}</a>
 						<br/> 
 						<a class="open" target="_blank" 
-							href="{{ zen_url }}/tickets/
-							{{ enhancement.zen_id }}"
+							href="{{ enhancement.zen_url }}"
 							>Z{{ enhancement.zen_id }}</a>
 					{% endif %}
 					</td>
@@ -244,8 +242,7 @@
 					<td class="td-centered">
 					{% if is_zendesk_user %}
 						<a class="open" target="_blank" 
-							href="{{ zen_url }}/tickets/
-							{{ enhancement.zen_id }}"
+							href="{{ enhancement.zen_url }}"
 							>Z{{ enhancement.zen_id }}</a>
 						<br/> 
 						<a class="open" target="_blank" 
@@ -257,8 +254,7 @@
 							>G{{ enhancement.git_id }}</a>
 						<br/> 
 						<a class="open" target="_blank" 
-							href="{{ zen_url }}/tickets/
-							{{ enhancement.zen_id }}"
+							href="{{ enhancement.zen_url }}"
 							>Z{{ enhancement.zen_id }}</a>
 					{% endif %}
 					</td>
@@ -315,7 +311,7 @@
 			<tr>
 				<td class="td-centered">
 					<a class="open" target="_blank" 
-						href="{{ zen_url }}/tickets/{{ enhancement.zen_id }}"
+						href="{{ enhancement.zen_url }}"
 						>Z{{ enhancement.zen_id }}</a>
 				</td>
 				<td>{{ enhancement.zen_subject }}</td>
@@ -366,7 +362,7 @@
 			<tr>
 				<td class="td-centered">
 					<a class="open" target="_blank" 
-						href="{{ zen_url }}/tickets/{{ enhancement.zen_id }}"
+						href="{{ enhancement.zen_url }}"
 						>Z{{ enhancement.zen_id }}</a>
 				</td>
 				<td>{{ enhancement.zen_subject }}</td>

--- a/gitzen/enhancement_tracking/views.py
+++ b/gitzen/enhancement_tracking/views.py
@@ -292,14 +292,14 @@ def confirm_git_oauth(request):
     """
     api_access_data = request.user.get_profile().api_access_data
 
-    if 'error' in request.GET:
-        api_access_data.git_token = ''
-        access_granted = False
-    else:
+    if 'code' in request.GET:
         code = request.GET['code']
         response = OAUTH2_HANDLER.get_token(code)
         api_access_data.git_token = response['access_token'][0]
         access_granted = True
+    else:
+        api_access_data.git_token = ''
+        access_granted = False
 
     api_access_data.save()
     product_name = api_access_data.product_name

--- a/gitzen/enhancement_tracking/views.py
+++ b/gitzen/enhancement_tracking/views.py
@@ -37,8 +37,7 @@ from gitzen.enhancement_tracking.models import UserProfile
 
 # Constant OAuth handler and authorization URL for access to GitHub's OAuth.
 OAUTH2_HANDLER = OAuth2(settings.CLIENT_ID, settings.CLIENT_SECRET, site='https://github.com/',
-                        redirect_uri='http://gitzen.policystat.com/' \
-                                     'confirm_git_oauth',
+                        redirect_uri='%s/confirm_git_oauth' % settings.ABSOLUTE_SITE_URL,
                         authorization_url='login/oauth/authorize',
                         token_url='login/oauth/access_token')
 GIT_AUTH_URL = OAUTH2_HANDLER.authorize_url('repo')

--- a/gitzen/settings.py
+++ b/gitzen/settings.py
@@ -196,7 +196,7 @@ if justonedb_dbi_url:
 # Allow an environment DATABASE_URL for configuration
 import dj_database_url
 DATABASES = {
-    'default': dj_database_url.config(default='postgres://localhost')
+    'default': dj_database_url.config(default=os.environ['GITZEN_DATABASE_URL'])
 }
 
 # If you'd like to override any settings for local development, put them in a


### PR DESCRIPTION
They're linking to: http://gitzen.policystat.com/home/policystat/tickets/2579 instead of http://policystat.zendesk.com/tickets/2579
