### PR TITLE
Error when updating the cache with new data

### DIFF
--- a/gitzen/enhancement_tracking/cache_actions.py
+++ b/gitzen/enhancement_tracking/cache_actions.py
@@ -150,7 +150,7 @@ def get_id_lists(zen_tickets, zen_fieldid):
     zen_user_ids = []
     for ticket in zen_tickets:
         zen_user_ids.append(ticket['requester_id'])
-    zen_user_ids = set(zen_user_ids) # Remove duplicates
+    zen_user_ids = list(set(zen_user_ids)) # Remove duplicates
 
     # Get GitHub issue numbers that are associated with the Zendesk tickets.
     git_issue_numbers = []
@@ -163,7 +163,7 @@ def get_id_lists(zen_tickets, zen_fieldid):
                 break
         if association_data and association_data[0] == 'gh':
             git_issue_numbers.append(int(association_data[1]))
-    git_issue_numbers = set(git_issue_numbers) # Remove duplicates
+    git_issue_numbers = list(set(git_issue_numbers)) # Remove duplicates
 
     return (zen_user_ids, git_issue_numbers)
 


### PR DESCRIPTION
I'm not sure exactly what the reproduction steps are, but I was working in gitzen and making a lot of changes today. Usually I just work from the page and don't reload it during a session, but I had made enough changes that I couldn't easily keep track of them in my head. Once I reloaded, I got this traceback (also, we should probably disable debug on our policystat environment and add error email sending):

```
Environment:

Request Method: GET
Request URL: foo/home/

Django Version: 1.3.1
Python Version: 2.7.2
Installed Applications:
['django.contrib.auth',
 'django.contrib.contenttypes',
 'django.contrib.sessions',
 'django.contrib.sites',
 'django.contrib.messages',
 'django.contrib.staticfiles',
 'gitzen.enhancement_tracking']
Installed Middleware:
('django.middleware.common.CommonMiddleware',
 'django.contrib.sessions.middleware.SessionMiddleware',
 'django.middleware.csrf.CsrfViewMiddleware',
 'django.contrib.auth.middleware.AuthenticationMiddleware',
 'django.contrib.messages.middleware.MessageMiddleware',
 'django.middleware.gzip.GZipMiddleware')


Traceback:
File "/app/.heroku/venv/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  111.                         response = callback(request, *callback_args, **callback_kwargs)
File "/app/.heroku/venv/lib/python2.7/site-packages/django/contrib/auth/decorators.py" in _wrapped_view
  23.                 return view_func(request, *args, **kwargs)
File "/app/gitzen/enhancement_tracking/views.py" in home
  426.         update_cache_index(api_access_data)
File "/app/gitzen/enhancement_tracking/cache_actions.py" in update_cache_index
  437.                 cache_data['git_issue_numbers'].extend(new_issue_numbers)

Exception Type: AttributeError at /home/
Exception Value: 'set' object has no attribute 'extend'

```
